### PR TITLE
feat(parse.go): add UDP support for VLESS protocol

### DIFF
--- a/pkg/adapter/clash/parse.go
+++ b/pkg/adapter/clash/parse.go
@@ -60,6 +60,7 @@ func parseVless(data proxy.Proxy, uuid string) (*Proxy, error) {
 		Port:   data.Port,
 		UUID:   uuid,
 		Flow:   vless.Flow,
+		UDP:    true,
 	}
 	setSecurityOptions(p, vless.Security, vless.SecurityConfig)
 	clashTransport(p, vless.Transport, vless.TransportConfig)


### PR DESCRIPTION
- Added `UDP: true` to `parseVless` function, enabling UDP support for VLESS protocol in rule-based mode.
- This change ensures that UDP traffic is proxied through Vless in rule-based mode, rather than only in global mode. Without this change, UDP traffic would bypass the proxy and connect directly.