### PR TITLE
将 flag / type 请求参数用于判断客户端类型并优先于 User-Agent

### DIFF
--- a/internal/logic/subscribe/subscribeLogic.go
+++ b/internal/logic/subscribe/subscribeLogic.go
@@ -46,7 +46,13 @@ func (l *SubscribeLogic) Handler(req *types.SubscribeRequest) (resp *types.Subsc
 		return nil, err
 	}
 
-	userAgent := strings.ToLower(l.ctx.Request.UserAgent())
+	// Priority: flag/type query parameter > User-Agent header
+	clientIdentifier := strings.ToLower(l.ctx.Request.UserAgent())
+	if req.Flag != "" {
+		clientIdentifier = strings.ToLower(req.Flag)
+	} else if req.Type != "" {
+		clientIdentifier = strings.ToLower(req.Type)
+	}
 
 	var targetApp, defaultApp *client.SubscribeApplication
 
@@ -56,9 +62,9 @@ func (l *SubscribeLogic) Handler(req *types.SubscribeRequest) (resp *types.Subsc
 			defaultApp = item
 		}
 
-		if strings.Contains(userAgent, u) {
+		if strings.Contains(clientIdentifier, u) {
 			// Special handling for Stash
-			if strings.Contains(userAgent, "stash") && !strings.Contains(u, "stash") {
+			if strings.Contains(clientIdentifier, "stash") && !strings.Contains(u, "stash") {
 				continue
 			}
 			targetApp = item
@@ -66,9 +72,9 @@ func (l *SubscribeLogic) Handler(req *types.SubscribeRequest) (resp *types.Subsc
 		}
 	}
 	if targetApp == nil {
-		l.Debugf("[SubscribeLogic] No matching client found", logger.Field("userAgent", userAgent))
+		l.Debugf("[SubscribeLogic] No matching client found", logger.Field("clientIdentifier", clientIdentifier))
 		if defaultApp == nil {
-			return nil, errors.Wrapf(xerr.NewErrCode(xerr.ERROR), "No matching client found for user agent: %s", userAgent)
+			return nil, errors.Wrapf(xerr.NewErrCode(xerr.ERROR), "No matching client found for: %s", clientIdentifier)
 		}
 		targetApp = defaultApp
 	}


### PR DESCRIPTION
feat(subscribe): enhance client identification logic by prioritizing flag/type over User-Agent

习惯上在订阅 URl 中添加 `flag` 或 `type` 参数用于客户端判断， [internal/handler/subscribe.go:25-26](https://github.com/perfect-panel/server/blob/b6a1739efaaaf25ee9bad31fd702a1f515b94b2f/internal/handler/subscribe.go#L25-L26) 中解析了相关参数但从未用于客户端选择， [internal/logic/subscribe/subscribeLogic.go:49-74](https://github.com/perfect-panel/server/blob/b6a1739efaaaf25ee9bad31fd702a1f515b94b2f/internal/logic/subscribe/subscribeLogic.go#L49-L74) 中的客户端匹配逻辑只看了 User-Agent 请求头，不看任何请求参数

此 PR 在 `subscribeLogic.go` 中完善了客户端匹配逻辑，将 `Flag` 和 `Type` 也用于客户端判断，并优先于 User-Agent