### PR TITLE
修复未启用但有配置的协议仍会下发给节点端的 bug

### DIFF
--- a/internal/logic/server/getServerConfigLogic.go
+++ b/internal/logic/server/getServerConfigLogic.go
@@ -69,10 +69,14 @@ func (l *GetServerConfigLogic) GetServerConfig(req *types.GetServerConfigRequest
 	}
 	var cfg map[string]interface{}
 	for _, protocol := range protocols {
-		if protocol.Type == protocolRequest {
+		if protocol.Enable && protocol.Type == protocolRequest {
 			cfg = l.compatible(protocol)
 			break
 		}
+	}
+
+	if cfg == nil {
+		return nil, fmt.Errorf("protocol %s not found or disabled", req.Protocol)
 	}
 
 	resp = &types.GetServerConfigResponse{

--- a/internal/logic/server/queryServerProtocolConfigLogic.go
+++ b/internal/logic/server/queryServerProtocolConfigLogic.go
@@ -41,6 +41,15 @@ func (l *QueryServerProtocolConfigLogic) QueryServerProtocolConfig(req *types.Qu
 	}
 	tool.DeepCopy(&protocols, dst)
 
+	// only return enabled protocols for node distribution
+	var enabledProtocols []types.Protocol
+	for _, p := range protocols {
+		if p.Enable {
+			enabledProtocols = append(enabledProtocols, p)
+		}
+	}
+	protocols = enabledProtocols
+
 	// filter by req.Protocols
 
 	if len(req.Protocols) > 0 {

--- a/internal/model/node/model.go
+++ b/internal/model/node/model.go
@@ -128,7 +128,7 @@ func (m *customServerModel) ClearNodeCache(ctx context.Context, params *FilterNo
 					return err
 				}
 				if len(keys) > 0 {
-					cacheKeys = append(keys, keys...)
+					cacheKeys = append(cacheKeys, keys...)
 				}
 				cursor = newCursor
 				if cursor == 0 {


### PR DESCRIPTION
fix(protocol): enable protocol filtering and error handling in server config logic

已做的修复：

1. v1 单协议下发增加 enable 校验
现在必须 `type` 匹配且 `enable=true` 才返回配置
2. v2 协议列表下发只返回启用协议
先过滤 `enable=true`，再做 `protocols` 参数过滤
3. 修复缓存清理 key 追加错误
从错误的 `append(keys, keys...)` 改为 `append(cacheKeys, keys...)`，避免缓存键集合构造异常。