### PR TITLE
fix: correct model reference in Node.BeforeUpdate hook

### DIFF
--- a/internal/model/node/node.go
+++ b/internal/model/node/node.go
@@ -46,19 +46,19 @@ func (n *Node) BeforeDelete(tx *gorm.DB) error {
 
 func (n *Node) BeforeUpdate(tx *gorm.DB) error {
 	var count int64
-	if err := tx.Set("gorm:query_option", "FOR UPDATE").Model(&Server{}).
+	if err := tx.Set("gorm:query_option", "FOR UPDATE").Model(&Node{}).
 		Where("sort = ? AND id != ?", n.Sort, n.Id).Count(&count).Error; err != nil {
 		return err
 	}
 	if count > 1 {
 		// reorder sort
 		if err := reorderSortWithNode(tx); err != nil {
-			logger.Errorf("[Server] BeforeUpdate reorderSort error: %v", err.Error())
+			logger.Errorf("[Node] BeforeUpdate reorderSort error: %v", err.Error())
 			return err
 		}
 		// get max sort
 		var maxSort int
-		if err := tx.Model(&Server{}).Select("MAX(sort)").Scan(&maxSort).Error; err != nil {
+		if err := tx.Model(&Node{}).Select("MAX(sort)").Scan(&maxSort).Error; err != nil {
 			return err
 		}
 		n.Sort = maxSort + 1


### PR DESCRIPTION
The BeforeUpdate method was incorrectly using `Model(&Server{})` instead of `Model(&Node{})` when checking for duplicate sort values and getting the maximum sort value. This is a copy-paste error from the Server model.

- Change Model(&Server{}) → Model(&Node{}) on line 49
- Change Model(&Server{}) → Model(&Node{}) on line 61
- Fix log tag from [Server] → [Node] on line 56 for consistency

This ensures that sort order maintenance works correctly for the nodes table, preventing duplicate sort values and data inconsistency.