### PR TITLE
Fix OAuth provider exposure and Telegram login state handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,3 +134,33 @@ jobs:
           binary_name: "ppanel-server"
           extra_files: LICENSE etc
           ldflags: -X "github.com/perfect-panel/server/pkg/constant.Version=${{env.VERSION}}" -X "github.com/perfect-panel/server/pkg/constant.BuildTime=${{env.BUILD_TIME}}"
+
+  trigger-ppanel-image:
+    name: Trigger ppanel image build
+    runs-on: ubuntu-latest
+    needs: releases-matrix
+    steps:
+      - name: Dispatch packaging build
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          SERVER_REPO: ${{ github.repository }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "GH_TOKEN secret is required to dispatch phenix3443/ppanel" >&2
+            exit 1
+          fi
+
+          curl -sSfL -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            https://api.github.com/repos/phenix3443/ppanel/dispatches \
+            -d @- <<EOF
+          {
+            "event_type": "trigger-build",
+            "client_payload": {
+              "tag": "${TAG}",
+              "server_repo": "${SERVER_REPO}"
+            }
+          }
+          EOF

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,12 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
-  build-docker:
+  build-image:
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: ppanel-server
@@ -22,11 +26,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Docker Hub
+      - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract version from git tag
         id: version
@@ -40,7 +45,7 @@ jobs:
         run: echo BUILD_TIME=$(date --iso-8601=seconds) >> ${GITHUB_ENV}
 
 
-      - name: Build and push Docker image for main release
+      - name: Build and push image for main release
         if: "!contains(github.ref_name, 'beta')"
         uses: docker/build-push-action@v6
         with:
@@ -51,10 +56,10 @@ jobs:
           build-args: |
             VERSION=${{ env.VERSION }}
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:latest
-            ${{ secrets.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}-${{ env.GIT_SHA }}
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}-${{ env.GIT_SHA }}
 
-      - name: Build and push Docker image for beta release
+      - name: Build and push image for beta release
         if: contains(github.ref_name, 'beta')
         uses: docker/build-push-action@v6
         with:
@@ -65,12 +70,12 @@ jobs:
           build-args: |
             VERSION=${{ env.VERSION }}
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:beta
-            ${{ secrets.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}-${{ env.GIT_SHA }}
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:beta
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}-${{ env.GIT_SHA }}
 
   release-notes:
     runs-on: ubuntu-latest
-    needs: build-docker
+    needs: build-image
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -88,7 +93,7 @@ jobs:
 
       - name: Run GoReleaser
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           goreleaser check
           goreleaser release --clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,6 @@ jobs:
 
   release-notes:
     runs-on: ubuntu-latest
-    needs: build-image
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,16 +144,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           TAG: ${{ github.ref_name }}
           SERVER_REPO: ${{ github.repository }}
+          TARGET_OWNER: ${{ github.repository_owner }}
         run: |
+          PPANEL_REPO="${TARGET_OWNER}/ppanel"
+
           if [ -z "${GH_TOKEN}" ]; then
-            echo "GH_TOKEN secret is required to dispatch phenix3443/ppanel" >&2
+            echo "GH_TOKEN secret is required to dispatch ${PPANEL_REPO}" >&2
             exit 1
           fi
 
           curl -sSfL -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${GH_TOKEN}" \
-            https://api.github.com/repos/phenix3443/ppanel/dispatches \
+            "https://api.github.com/repos/${PPANEL_REPO}/dispatches" \
             -d @- <<EOF
           {
             "event_type": "trigger-build",

--- a/internal/logic/auth/oauth/oAuthLoginLogic.go
+++ b/internal/logic/auth/oauth/oAuthLoginLogic.go
@@ -46,7 +46,8 @@ func (l *OAuthLoginLogic) OAuthLogin(req *types.OAthLoginRequest) (resp *types.O
 		uri, err = l.github()
 	case "facebook":
 		uri, err = l.facebook()
-
+	default:
+		return nil, errors.Wrapf(xerr.NewErrCode(xerr.ERROR), "oauth login method not supported: %v", req.Method)
 	}
 	if err != nil {
 		l.Errorw("OAuthLogin ", logger.Field("error", err.Error()))
@@ -62,11 +63,17 @@ func (l *OAuthLoginLogic) google(req *types.OAthLoginRequest) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if authMethod.Enabled == nil || !*authMethod.Enabled {
+		return "", errors.Wrapf(xerr.NewErrCode(xerr.ERROR), "google oauth is disabled")
+	}
 	var cfg auth.GoogleAuthConfig
 	err = json.Unmarshal([]byte(authMethod.Config), &cfg)
 	if err != nil {
 		l.Errorw("error unmarshal google config: %v", logger.Field("config", authMethod.Config), logger.Field("error", err.Error()))
 		return "", err
+	}
+	if cfg.ClientId == "" || cfg.ClientSecret == "" {
+		return "", errors.Wrapf(xerr.NewErrCode(xerr.ERROR), "google oauth config is incomplete")
 	}
 	client := google.New(&google.Config{
 		ClientID:     cfg.ClientId,
@@ -92,11 +99,17 @@ func (l *OAuthLoginLogic) apple(req *types.OAthLoginRequest) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if authMethod.Enabled == nil || !*authMethod.Enabled {
+		return "", errors.Wrapf(xerr.NewErrCode(xerr.ERROR), "apple oauth is disabled")
+	}
 	var cfg auth.AppleAuthConfig
 	err = json.Unmarshal([]byte(authMethod.Config), &cfg)
 	if err != nil {
 		l.Errorw("error unmarshal apple config: %v", logger.Field("config", authMethod.Config), logger.Field("error", err.Error()))
 		return "", err
+	}
+	if cfg.TeamID == "" || cfg.KeyID == "" || cfg.ClientId == "" || cfg.ClientSecret == "" || cfg.RedirectURL == "" {
+		return "", errors.Wrapf(xerr.NewErrCode(xerr.ERROR), "apple oauth config is incomplete")
 	}
 	uri := "https://appleid.apple.com/auth/authorize?client_id=%s&redirect_uri=%s&response_type=code&state=%s&scope=name email&response_mode=form_post"
 	// generate the state code
@@ -116,16 +129,22 @@ func (l *OAuthLoginLogic) telegram(req *types.OAthLoginRequest) (string, error) 
 	if err != nil {
 		return "", err
 	}
+	if authMethod.Enabled == nil || !*authMethod.Enabled {
+		return "", errors.Wrapf(xerr.NewErrCode(xerr.ERROR), "telegram oauth is disabled")
+	}
 	var cfg auth.TelegramAuthConfig
 	err = json.Unmarshal([]byte(authMethod.Config), &cfg)
 	if err != nil {
 		l.Errorw("error unmarshal apple config: %v", logger.Field("config", authMethod.Config), logger.Field("error", err.Error()))
 		return "", err
 	}
+	if cfg.BotToken == "" {
+		return "", errors.Wrapf(xerr.NewErrCode(xerr.ERROR), "telegram oauth config is incomplete")
+	}
 	// generate the state code
 	code := random.KeyNew(8, 1)
 	// save the state code
-	err = l.svcCtx.Redis.Set(l.ctx, fmt.Sprintf("apple:%s", code), req.Redirect, 5*60*time.Second).Err()
+	err = l.svcCtx.Redis.Set(l.ctx, fmt.Sprintf("telegram:%s", code), req.Redirect, 5*60*time.Second).Err()
 	if err != nil {
 		l.Errorw("error save state code to redis", logger.Field("code", code), logger.Field("error", err.Error()))
 		return "", errors.Wrapf(xerr.NewErrCode(xerr.ERROR), "error save state code to redis")

--- a/internal/logic/common/getGlobalConfigLogic.go
+++ b/internal/logic/common/getGlobalConfigLogic.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/perfect-panel/server/internal/model/auth"
 	"github.com/perfect-panel/server/internal/report"
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/internal/types"
@@ -71,12 +72,14 @@ func (l *GetGlobalConfigLogic) GetGlobalConfig() (resp *types.GetGlobalConfigRes
 	}
 
 	for _, method := range authMethods {
-		if *method.Enabled {
-			methods = append(methods, method.Method)
-			if method.Method == "device" {
-				_ = json.Unmarshal([]byte(method.Config), &resp.Auth.Device)
-				resp.Auth.Device.Enable = true
-			}
+		if !isPublicAuthMethodAvailable(method) {
+			continue
+		}
+
+		methods = append(methods, method.Method)
+		if method.Method == "device" {
+			_ = json.Unmarshal([]byte(method.Config), &resp.Auth.Device)
+			resp.Auth.Device.Enable = true
 		}
 	}
 	resp.OAuthMethods = methods
@@ -89,4 +92,31 @@ func (l *GetGlobalConfigLogic) GetGlobalConfig() (resp *types.GetGlobalConfigRes
 	// web ads config
 	resp.WebAd = webAds.Value == "true"
 	return
+}
+
+func isPublicAuthMethodAvailable(method *auth.Auth) bool {
+	if method == nil || method.Enabled == nil || !*method.Enabled {
+		return false
+	}
+
+	switch method.Method {
+	case "email", "mobile", "device":
+		return true
+	case "google":
+		var cfg auth.GoogleAuthConfig
+		return cfg.Unmarshal(method.Config) == nil && cfg.ClientId != "" && cfg.ClientSecret != ""
+	case "apple":
+		var cfg auth.AppleAuthConfig
+		return cfg.Unmarshal(method.Config) == nil &&
+			cfg.TeamID != "" &&
+			cfg.KeyID != "" &&
+			cfg.ClientId != "" &&
+			cfg.ClientSecret != "" &&
+			cfg.RedirectURL != ""
+	case "telegram":
+		var cfg auth.TelegramAuthConfig
+		return cfg.Unmarshal(method.Config) == nil && cfg.BotToken != ""
+	default:
+		return false
+	}
 }

--- a/internal/logic/common/getGlobalConfigLogic_test.go
+++ b/internal/logic/common/getGlobalConfigLogic_test.go
@@ -1,0 +1,71 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/perfect-panel/server/internal/model/auth"
+)
+
+func TestIsPublicAuthMethodAvailable(t *testing.T) {
+	enabled := true
+	disabled := false
+
+	tests := []struct {
+		name   string
+		method *auth.Auth
+		want   bool
+	}{
+		{
+			name: "email enabled",
+			method: &auth.Auth{
+				Method:  "email",
+				Enabled: &enabled,
+			},
+			want: true,
+		},
+		{
+			name: "google enabled with config",
+			method: &auth.Auth{
+				Method:  "google",
+				Enabled: &enabled,
+				Config:  `{"client_id":"client-id","client_secret":"client-secret","redirect_url":""}`,
+			},
+			want: true,
+		},
+		{
+			name: "telegram enabled without bot token",
+			method: &auth.Auth{
+				Method:  "telegram",
+				Enabled: &enabled,
+				Config:  `{"bot_token":"","enable_notify":false,"webhook_domain":""}`,
+			},
+			want: false,
+		},
+		{
+			name: "github remains hidden",
+			method: &auth.Auth{
+				Method:  "github",
+				Enabled: &enabled,
+				Config:  `{"client_id":"client-id","client_secret":"client-secret","redirect_url":"https://example.com"}`,
+			},
+			want: false,
+		},
+		{
+			name: "disabled method hidden",
+			method: &auth.Auth{
+				Method:  "telegram",
+				Enabled: &disabled,
+				Config:  `{"bot_token":"token"}`,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isPublicAuthMethodAvailable(tt.method); got != tt.want {
+				t.Fatalf("isPublicAuthMethodAvailable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/svc/mmdb.go
+++ b/internal/svc/mmdb.go
@@ -18,17 +18,11 @@ type IPLocation struct {
 }
 
 func NewIPLocation(path string) (*IPLocation, error) {
-
-	// 检查文件是否存在
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		logger.Infof("[GeoIP] Database not found, downloading from %s", GeoIPDBURL)
-		// 文件不存在，下载数据库
-		err := DownloadGeoIPDatabase(GeoIPDBURL, path)
-		if err != nil {
-			logger.Errorf("[GeoIP] Failed to download database: %v", err.Error())
-			return nil, err
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil, os.ErrNotExist
 		}
-		logger.Infof("[GeoIP] Database downloaded successfully")
+		return nil, err
 	}
 
 	db, err := geoip2.Open(path)

--- a/internal/svc/serviceContext.go
+++ b/internal/svc/serviceContext.go
@@ -22,6 +22,7 @@ import (
 	"github.com/perfect-panel/server/internal/model/traffic"
 	"github.com/perfect-panel/server/internal/model/user"
 	"github.com/perfect-panel/server/pkg/limit"
+	"github.com/perfect-panel/server/pkg/logger"
 	"github.com/perfect-panel/server/pkg/nodeMultiplier"
 	"github.com/perfect-panel/server/pkg/orm"
 
@@ -77,7 +78,8 @@ func NewServiceContext(c config.Config) *ServiceContext {
 	// IP location initialize
 	geoIP, err := NewIPLocation("./cache/GeoLite2-City.mmdb")
 	if err != nil {
-		panic(err.Error())
+		logger.Errorf("[GeoIP] Failed to initialize database, continuing without GeoIP support: %v", err.Error())
+		geoIP = nil
 	}
 
 	rds := redis.NewClient(&redis.Options{


### PR DESCRIPTION
## Summary
- fix Telegram OAuth state persistence to use the correct Redis key prefix
- only expose public auth methods that are both implemented and sufficiently configured
- return an explicit error for unsupported OAuth login methods

## Testing
- go test ./internal/logic/common ./internal/logic/auth/oauth