### PR TITLE
fix(subscribe): clear nodes field when node_tags is set

### DIFF
--- a/internal/logic/admin/subscribe/updateSubscribeLogic.go
+++ b/internal/logic/admin/subscribe/updateSubscribeLogic.go
@@ -42,6 +42,11 @@ func (l *UpdateSubscribeLogic) UpdateSubscribe(req *types.UpdateSubscribeRequest
 		val, _ := json.Marshal(req.Discount)
 		discount = string(val)
 	}
+	// When NodeTags is set, clear Nodes to avoid AND-combined query returning wrong results (#94)
+	nodes := tool.Int64SliceToString(req.Nodes)
+	if len(req.NodeTags) > 0 {
+		nodes = ""
+	}
 	sub := &subscribe.Subscribe{
 		Id:                req.Id,
 		Name:              req.Name,
@@ -56,7 +61,7 @@ func (l *UpdateSubscribeLogic) UpdateSubscribe(req *types.UpdateSubscribeRequest
 		SpeedLimit:        req.SpeedLimit,
 		DeviceLimit:       req.DeviceLimit,
 		Quota:             req.Quota,
-		Nodes:             tool.Int64SliceToString(req.Nodes),
+		Nodes:             nodes,
 		NodeTags:          tool.StringSliceToString(req.NodeTags),
 		Show:              req.Show,
 		Sell:              req.Sell,


### PR DESCRIPTION
## 问题

当订阅更新时同时设置了 `node_tags`，但 `nodes` 字段没有被清空。导致节点过滤时同时存在 `NodeId` 和 `Tag` 两个条件，以 AND 关系组合查询，最终只返回同时满足两个条件的节点，造成节点缺失。

## 修复

当 `node_tags` 非空时，自动将 `nodes` 清空，确保两种过滤方式互斥。

Closes #94