### PR TITLE
fix(auth): use random token for trial subscriptions

### DIFF
--- a/internal/logic/auth/deviceLoginLogic.go
+++ b/internal/logic/auth/deviceLoginLogic.go
@@ -257,7 +257,7 @@ func (l *DeviceLoginLogic) activeTrial(userId int64, db *gorm.DB) error {
 
 	startTime := time.Now()
 	expireTime := tool.AddTime(l.svcCtx.Config.Register.TrialTimeUnit, l.svcCtx.Config.Register.TrialTime, startTime)
-	subscribeToken := uuidx.SubscribeToken(fmt.Sprintf("Trial-%v", userId))
+uuidx.SubscribeToken(fmt.Sprintf("Trial-%v-%s", uid, uuidx.NewUUID().String()))
 	subscribeUUID := uuidx.NewUUID().String()
 
 	userSub := &user.Subscribe{

--- a/internal/logic/auth/oauth/oAuthLoginGetTokenLogic.go
+++ b/internal/logic/auth/oauth/oAuthLoginGetTokenLogic.go
@@ -813,7 +813,7 @@ func (l *OAuthLoginGetTokenLogic) activeTrial(uid int64, requestID string) error
 
 	startTime := time.Now()
 	expireTime := tool.AddTime(l.svcCtx.Config.Register.TrialTimeUnit, l.svcCtx.Config.Register.TrialTime, startTime)
-	subscribeToken := uuidx.SubscribeToken(fmt.Sprintf("Trial-%v", uid))
+	subscribeToken := uuidx.SubscribeToken(fmt.Sprintf("Trial-%v-%s", uid, uuidx.NewUUID().String()))
 	subscribeUUID := uuidx.NewUUID().String()
 
 	l.Debugw("creating trial subscription",

--- a/internal/logic/auth/telephoneUserRegisterLogic.go
+++ b/internal/logic/auth/telephoneUserRegisterLogic.go
@@ -241,7 +241,7 @@ func (l *TelephoneUserRegisterLogic) activeTrial(uid int64) error {
 		Traffic:     sub.Traffic,
 		Download:    0,
 		Upload:      0,
-		Token:       uuidx.SubscribeToken(fmt.Sprintf("Trial-%v", uid)),
+		Token:       uuidx.SubscribeToken(fmt.Sprintf("Trial-%v-%s", uid, uuidx.NewUUID().String())),
 		UUID:        uuidx.NewUUID().String(),
 		Status:      1,
 	}

--- a/internal/logic/auth/userRegisterLogic.go
+++ b/internal/logic/auth/userRegisterLogic.go
@@ -230,7 +230,7 @@ func (l *UserRegisterLogic) activeTrial(uid int64) error {
 		Traffic:     sub.Traffic,
 		Download:    0,
 		Upload:      0,
-		Token:       uuidx.SubscribeToken(fmt.Sprintf("Trial-%v", uid)),
+		Token:       uuidx.SubscribeToken(fmt.Sprintf("Trial-%v-%s", uid, uuidx.NewUUID().String())),
 		UUID:        uuidx.NewUUID().String(),
 		Status:      1,
 	}


### PR DESCRIPTION
## 问题

试用订阅激活后，用户必须手动点击「重置」才能使用订阅链接。

根本原因：试用订阅 token 使用确定性哈希生成（`SubscribeToken("Trial-{uid}")`），同一用户永远生成相同 token。如果 Redis cache 中存有任何脏数据，订阅就无法正常访问，直到 reset（reset 使用了带时间戳的随机 token）。

## 修复

四处注册路径统一改为随机 token：
- `userRegisterLogic`
- `telephoneUserRegisterLogic`
- `oAuthLoginGetTokenLogic`
- `deviceLoginLogic`

每次注册时 token 都是唯一随机值，杜绝 cache 冲突。

Closes #116