### PR TITLE
feat(tool): add sha256salt password algorithm for SSPanel migration

### DIFF
--- a/internal/logic/public/user/updateUserPasswordLogic.go
+++ b/internal/logic/public/user/updateUserPasswordLogic.go
@@ -34,6 +34,10 @@ func (l *UpdateUserPasswordLogic) UpdateUserPassword(req *types.UpdateUserPasswo
 	userInfo := l.ctx.Value(constant.CtxKeyUser).(*user.User)
 	//update the password
 	userInfo.Password = tool.EncodePassWord(req.Password)
+	// Reset algo to default, otherwise a migrated user (e.g. algo=md5salt/sha256salt)
+	// would be locked out: the new hash is pbkdf2 but verification would still use the
+	// old algorithm. Mirrors resetPasswordLogic and updateUserBasicInfoLogic.
+	userInfo.Algo = "default"
 	if err := l.svcCtx.Store.User().Update(l.ctx, userInfo); err != nil {
 		return errors.Wrapf(xerr.NewErrCode(xerr.DatabaseUpdateError), "Update user password error")
 	}

--- a/pkg/tool/encryption.go
+++ b/pkg/tool/encryption.go
@@ -46,6 +46,10 @@ func MultiPasswordVerify(algo, salt, password, hash string) bool {
 	case "md5salt":
 		sum := md5.Sum([]byte(password + salt))
 		return hex.EncodeToString(sum[:]) == hash
+	case "sha256salt":
+		// sha256(password + salt), used by SSPanel-style panels (pwdMethod=sha256)
+		sum := sha256.Sum256([]byte(password + salt))
+		return hex.EncodeToString(sum[:]) == hash
 	case "default": // PPanel's default algorithm
 		return VerifyPassWord(password, hash)
 	case "bcrypt":

--- a/pkg/tool/encryption_test.go
+++ b/pkg/tool/encryption_test.go
@@ -13,3 +13,14 @@ func TestMultiPasswordVerify(t *testing.T) {
 	status := MultiPasswordVerify("bcrypt", "", "admin1", pwd)
 	t.Logf("MultiPasswordVerify: %v", status)
 }
+
+func TestMultiPasswordVerifySha256Salt(t *testing.T) {
+	// sha256("123456" + "ppanel")
+	hash := "4fb4d5ec8ec384d63cfe1faf2d9610140b310f68fd72eb0df90d3027b702b35f"
+	if !MultiPasswordVerify("sha256salt", "ppanel", "123456", hash) {
+		t.Fatal("sha256salt: correct password should verify")
+	}
+	if MultiPasswordVerify("sha256salt", "ppanel", "wrong", hash) {
+		t.Fatal("sha256salt: wrong password must not verify")
+	}
+}


### PR DESCRIPTION
## Purpose

Make it possible to migrate users from SSPanel-style panels into PPanel without
forcing a password reset, and fix a related lock-out bug for any non-default
password algorithm.

This PR contains two related commits:

### 1. feat: add `sha256salt` password algorithm

SSPanel-style panels with `pwdMethod=sha256` store `sha256(password + global_salt)`.
`MultiPasswordVerify` already supports `md5salt` = `md5(password + salt)`, but has no
sha256 equivalent — only `sha256` = `sha256(password)` without salt — so those hashes
cannot be verified today.

Adds a `sha256salt` case computing `sha256(password + salt)`, mirroring `md5salt`.
Operators can then import users with `algo=sha256salt`, `salt=<old global salt>`,
`password=<old hash>`, and users keep their existing passwords.

### 2. fix: reset `algo` to `default` on self-service password change

`updateUserPassword` wrote a new pbkdf2 hash via `EncodePassWord` but left the user's
`Algo` unchanged. For a migrated user (`algo=md5salt`/`sha256salt`) this locks them out:
the stored hash becomes pbkdf2 while verification still uses the old algorithm.

`resetPasswordLogic` and `updateUserBasicInfoLogic` already set `Algo="default"` in the
same situation; this aligns `updateUserPassword` with them.

> This bug is latent on a fresh install (everyone is `algo=default`), so it only
> surfaces once non-default-algo users exist — i.e. exactly the migration case this PR
> enables.

## Notes

Password creation paths are unchanged (still pbkdf2 via `EncodePassWord`); commit 1 only
affects verification of imported accounts.

## Testing

Added `TestMultiPasswordVerifySha256Salt` covering both correct and incorrect passwords.
