### PR TITLE
feat(subscribe): add admin toggle to show/hide the user tutorial section

### DIFF
--- a/apis/types.api
+++ b/apis/types.api
@@ -67,6 +67,7 @@ type (
 		PanDomain       bool   `json:"pan_domain"`
 		UserAgentLimit  bool   `json:"user_agent_limit"`
 		UserAgentList   string `json:"user_agent_list"`
+		ShowTutorial    bool   `json:"show_tutorial"`
 	}
 	VerifyCodeConfig {
 		VerifyCodeExpireTime int64 `json:"verify_code_expire_time"`

--- a/initialize/migrate/database/mysql/02130_subscribe_tutorial.down.sql
+++ b/initialize/migrate/database/mysql/02130_subscribe_tutorial.down.sql
@@ -1,0 +1,1 @@
+DELETE FROM `system` WHERE `category` = 'subscribe' AND `key` = 'ShowTutorial';

--- a/initialize/migrate/database/mysql/02130_subscribe_tutorial.up.sql
+++ b/initialize/migrate/database/mysql/02130_subscribe_tutorial.up.sql
@@ -1,0 +1,5 @@
+INSERT INTO `system` (`category`, `key`, `value`, `type`, `desc`, `created_at`, `updated_at`)
+SELECT 'subscribe', 'ShowTutorial', 'true', 'bool', 'Show tutorial section on the user document page', '2025-04-22 14:25:16.639', '2025-04-22 14:25:16.639'
+    WHERE NOT EXISTS (
+    SELECT 1 FROM `system` WHERE `category` = 'subscribe' AND `key` = 'ShowTutorial'
+);

--- a/initialize/migrate/database/postgres/02130_subscribe_tutorial.down.sql
+++ b/initialize/migrate/database/postgres/02130_subscribe_tutorial.down.sql
@@ -1,0 +1,1 @@
+DELETE FROM "system" WHERE "category" = 'subscribe' AND "key" = 'ShowTutorial';

--- a/initialize/migrate/database/postgres/02130_subscribe_tutorial.up.sql
+++ b/initialize/migrate/database/postgres/02130_subscribe_tutorial.up.sql
@@ -1,0 +1,5 @@
+INSERT INTO "system" ("category", "key", "value", "type", "desc", "created_at", "updated_at")
+SELECT 'subscribe', 'ShowTutorial', 'true', 'bool', 'Show tutorial section on the user document page', '2025-04-22 14:25:16.639', '2025-04-22 14:25:16.639'
+    WHERE NOT EXISTS (
+    SELECT 1 FROM "system" WHERE "category" = 'subscribe' AND "key" = 'ShowTutorial'
+);

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,6 +68,7 @@ type SubscribeConfig struct {
 	PanDomain       bool   `yaml:"PanDomain" default:"false"`
 	UserAgentLimit  bool   `yaml:"UserAgentLimit" default:"false"`
 	UserAgentList   string `yaml:"UserAgentList" default:""`
+	ShowTutorial    bool   `yaml:"ShowTutorial" default:"true"`
 }
 
 type RegisterConfig struct {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -2175,6 +2175,7 @@ type SubscribeConfig struct {
 	PanDomain       bool   `json:"pan_domain"`
 	UserAgentLimit  bool   `json:"user_agent_limit"`
 	UserAgentList   string `json:"user_agent_list"`
+	ShowTutorial    bool   `json:"show_tutorial"`
 }
 
 type SubscribeDiscount struct {


### PR DESCRIPTION
## Purpose

The user document page's **tutorial** section is currently gated only by the build-time `VITE_TUTORIAL_DOCUMENT` frontend env var, so operators can't hide it without rebuilding the frontend. This makes it a runtime, admin-editable setting.

## Change

Adds one field to `SubscribeConfig`:

| Field | Type | Default | Purpose |
|---|---|---|---|
| `ShowTutorial` (`show_tutorial`) | bool | `true` | Show/hide the tutorial section on the user document page |

- `apis/types.api` + regenerated `internal/types/types.go`: new field.
- `internal/config/config.go`: new field, default `true`.
- Migration `02130_subscribe_tutorial` (mysql + postgres): idempotently seeds the default so **existing installs keep showing tutorials** (a missing bool row would otherwise default to false/hidden).

It flows to the frontend through the existing `common.subscribe` global config and is editable via the existing `PUT /v1/admin/system/subscribe_config` (which already uses `convertedConfigFields`, so the bool serializes correctly).

Companion frontend PR adds the toggle to the subscribe config form and gates the user-side tutorial section on `common.subscribe.show_tutorial`.

## Note for reviewers

Placed under `subscribe` config to reuse the existing config plumbing (no new goctl-generated routes/handlers). Happy to relocate to a dedicated section if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)