### PR TITLE
feat(subscribe): show a notice when traffic is exhausted, not only when expired

### DIFF
--- a/internal/logic/public/subscribe/queryUserSubscribeNodeListLogic.go
+++ b/internal/logic/public/subscribe/queryUserSubscribeNodeListLogic.go
@@ -88,7 +88,7 @@ func (l *QueryUserSubscribeNodeListLogic) QueryUserSubscribeNodeList() (resp *ty
 
 func (l *QueryUserSubscribeNodeListLogic) getServers(userSub *user.Subscribe) (userSubscribeNodes []*types.UserSubscribeNodeInfo, err error) {
 	userSubscribeNodes = make([]*types.UserSubscribeNodeInfo, 0)
-	if l.isSubscriptionExpired(userSub) {
+	if l.isSubscriptionExpired(userSub) || l.isTrafficExhausted(userSub) {
 		return l.createExpiredServers(), nil
 	}
 
@@ -219,6 +219,12 @@ func (l *QueryUserSubscribeNodeListLogic) filterSubscribeNodes(nodeIds []int64, 
 
 func (l *QueryUserSubscribeNodeListLogic) isSubscriptionExpired(userSub *user.Subscribe) bool {
 	return userSub.ExpireTime.Unix() < time.Now().Unix() && userSub.ExpireTime.Unix() != 0
+}
+
+// isTrafficExhausted reports whether the subscription has used up its traffic
+// quota (Traffic == 0 means unlimited).
+func (l *QueryUserSubscribeNodeListLogic) isTrafficExhausted(userSub *user.Subscribe) bool {
+	return userSub.Traffic > 0 && userSub.Download+userSub.Upload >= userSub.Traffic
 }
 
 func (l *QueryUserSubscribeNodeListLogic) createExpiredServers() []*types.UserSubscribeNodeInfo {

--- a/internal/logic/subscribe/subscribeLogic.go
+++ b/internal/logic/subscribe/subscribeLogic.go
@@ -238,7 +238,11 @@ func (l *SubscribeLogic) logSubscribeActivity(subscribeStatus bool, userSub *use
 
 func (l *SubscribeLogic) getServers(userSub *user.Subscribe) ([]*node.Node, error) {
 	if l.isSubscriptionExpired(userSub) {
-		return l.createExpiredServers(), nil
+		return l.createNoticeServers("订阅已过期 / Subscribe Expired"), nil
+	}
+
+	if l.isTrafficExhausted(userSub) {
+		return l.createNoticeServers("流量已用尽 / Traffic Exhausted"), nil
 	}
 
 	subDetails, err := l.svc.Store.Subscribe().FindOne(l.ctx, userSub.SubscribeId)
@@ -280,19 +284,29 @@ func (l *SubscribeLogic) isSubscriptionExpired(userSub *user.Subscribe) bool {
 	return userSub.ExpireTime.Unix() < time.Now().Unix() && userSub.ExpireTime.Unix() != 0
 }
 
-func (l *SubscribeLogic) createExpiredServers() []*node.Node {
+// isTrafficExhausted reports whether the subscription has used up its traffic
+// quota. Traffic == 0 means unlimited. Mirrors the condition used by
+// FindTrafficExceededSubscribes (upload + download >= traffic AND traffic > 0).
+func (l *SubscribeLogic) isTrafficExhausted(userSub *user.Subscribe) bool {
+	return userSub.Traffic > 0 && userSub.Download+userSub.Upload >= userSub.Traffic
+}
+
+// createNoticeServers returns placeholder (non-functional) nodes whose names
+// carry a notice (e.g. expired / traffic exhausted) so clients display the
+// reason instead of silently failing.
+func (l *SubscribeLogic) createNoticeServers(message string) []*node.Node {
 	enable := true
 	host := l.getFirstHostLine()
 
 	return []*node.Node{
 		{
-			Name:    "Subscribe Expired",
+			Name:    message,
 			Tags:    "",
 			Port:    18080,
 			Address: "127.0.0.1",
 			Server: &node.Server{
 				Id:        1,
-				Name:      "Subscribe Expired",
+				Name:      message,
 				Protocols: "[{\"type\":\"shadowsocks\",\"cipher\":\"aes-256-gcm\",\"port\":1}]",
 			},
 			Protocol: "shadowsocks",
@@ -305,7 +319,7 @@ func (l *SubscribeLogic) createExpiredServers() []*node.Node {
 			Address: "127.0.0.1",
 			Server: &node.Server{
 				Id:        1,
-				Name:      "Subscribe Expired",
+				Name:      message,
 				Protocols: "[{\"type\":\"shadowsocks\",\"cipher\":\"aes-256-gcm\",\"port\":1}]",
 			},
 			Protocol: "shadowsocks",


### PR DESCRIPTION
## Problem

When a subscription is delivered, only **time-expiry** is surfaced to the client: `getServers` returns placeholder "Subscribe Expired" nodes via `isSubscriptionExpired`. A subscription whose **traffic quota is used up** (yet not time-expired) is still served the **real node list** — the client connects to nodes that don't work, with no indication why.

The scheduler already detects this state (`FindTrafficExceededSubscribes`: `upload + download >= traffic AND traffic > 0`) and marks such subscriptions Finished, but the delivery path never checks traffic.

## Change (backend only)

- **`subscribeLogic.go`** (client subscription delivery): generalize `createExpiredServers()` → `createNoticeServers(message)` and return a **bilingual notice node** for both cases:
  - expired → `订阅已过期 / Subscribe Expired`
  - exhausted → `流量已用尽 / Traffic Exhausted`
- **`queryUserSubscribeNodeListLogic.go`** (`/v1/public/subscribe/node/list`, portal node preview): also treat traffic-exhausted as unavailable, consistent with expired.

`isTrafficExhausted` mirrors the existing `FindTrafficExceededSubscribes` condition (`traffic > 0 && upload + download >= traffic`; `traffic == 0` = unlimited). Expiry takes precedence when both are true.

No DB/migration/API/frontend changes.

## Notes

- The `/v1/public/subscribe/node/list` endpoint isn't currently called by the official frontend, but it's a public endpoint reserved for the frontend, so the two delivery paths are kept consistent.
- Purely status-based states (cancelled/stopped) remain unblocked at the delivery layer — this only adds the traffic-exhausted notice, matching the existing expired-notice UX.
- Notice text is hardcoded bilingual for now; could be made configurable/i18n later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)