### PR TITLE
feat(document): subscription-gated conditional blocks in document content

### DIFF
--- a/internal/logic/public/document/queryDocumentDetailLogic.go
+++ b/internal/logic/public/document/queryDocumentDetailLogic.go
@@ -2,13 +2,24 @@ package document
 
 import (
 	"context"
+	"regexp"
 
+	"github.com/perfect-panel/server/internal/model/user"
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/internal/types"
+	"github.com/perfect-panel/server/pkg/constant"
 	"github.com/perfect-panel/server/pkg/logger"
 	"github.com/perfect-panel/server/pkg/tool"
 	"github.com/perfect-panel/server/pkg/xerr"
 	"github.com/pkg/errors"
+)
+
+// Subscription-gated conditional blocks in document content. Stripped
+// server-side so gated content (e.g. shared credentials) never reaches users
+// without an active subscription.
+var (
+	reIfSubscribed    = regexp.MustCompile(`(?s)\{\{#if_subscribed\}\}(.*?)\{\{/if_subscribed\}\}`)
+	reIfNotSubscribed = regexp.MustCompile(`(?s)\{\{#if_not_subscribed\}\}(.*?)\{\{/if_not_subscribed\}\}`)
 )
 
 type QueryDocumentDetailLogic struct {
@@ -35,5 +46,36 @@ func (l *QueryDocumentDetailLogic) QueryDocumentDetail(req *types.QueryDocumentD
 	}
 	resp = &types.Document{}
 	tool.DeepCopy(resp, data)
+	resp.Content = l.renderConditional(resp.Content)
 	return
+}
+
+// renderConditional keeps or drops {{#if_subscribed}}...{{/if_subscribed}} and
+// {{#if_not_subscribed}}...{{/if_not_subscribed}} blocks based on whether the
+// current user has an active subscription. Done here (server-side) so gated
+// content is never sent to users who shouldn't see it.
+func (l *QueryDocumentDetailLogic) renderConditional(content string) string {
+	if content == "" {
+		return content
+	}
+
+	hasSubscription := false
+	if u, ok := l.ctx.Value(constant.CtxKeyUser).(*user.User); ok && u != nil {
+		// status 1 = active
+		subs, err := l.svcCtx.Store.User().QueryUserSubscribe(l.ctx, u.Id, 1)
+		if err != nil {
+			l.Errorw("[QueryDocumentDetailLogic] QueryUserSubscribe error", logger.Field("error", err.Error()), logger.Field("user_id", u.Id))
+		} else {
+			hasSubscription = len(subs) > 0
+		}
+	}
+
+	if hasSubscription {
+		content = reIfSubscribed.ReplaceAllString(content, "$1")
+		content = reIfNotSubscribed.ReplaceAllString(content, "")
+	} else {
+		content = reIfSubscribed.ReplaceAllString(content, "")
+		content = reIfNotSubscribed.ReplaceAllString(content, "$1")
+	}
+	return content
 }


### PR DESCRIPTION
## Purpose

Let admins show parts of a document **only to users with an active subscription** (e.g. a shared Apple ID), and other parts only to non-subscribers — enforced **server-side** so gated content never reaches users who shouldn't see it.

## Syntax

```
{{#if_subscribed}}
Shared Apple ID: xxx  /  password: xxx
{{/if_subscribed}}

{{#if_not_subscribed}}
Purchase any plan to reveal the shared Apple ID.
{{/if_not_subscribed}}
```

## How

In `QueryDocumentDetail` (the `/v1/public/document/detail` endpoint, already behind `AuthMiddleware`), after loading the document:

1. Check whether the current user has an **active** subscription (`QueryUserSubscribe(ctx, userId, 1)`, `len > 0`).
2. Strip the conditional blocks accordingly (keep `if_subscribed` for subscribers, `if_not_subscribed` for everyone else).

Because this runs **server-side**, the gated content is removed from the response for non-subscribers — they can't extract it from the API (unlike client-side hiding). Safe default: if the user can't be resolved, gated content is hidden.

Single file, no schema/API/migration change.

## Companion

The frontend variable-substitution PR (perfect-panel/frontend#80) documents this syntax in the admin document editor's *Template variables* hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)