### PR TITLE
feat: log system performance optimization and timezone unification

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -23,6 +23,7 @@ import (
 	"github.com/perfect-panel/server/pkg/logger"
 	"github.com/perfect-panel/server/pkg/orm"
 	"github.com/perfect-panel/server/pkg/service"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/tool"
 	"github.com/perfect-panel/server/queue"
 	"github.com/perfect-panel/server/scheduler"
@@ -82,6 +83,10 @@ func getServers() *service.Group {
 		}
 	}
 	conf.MustLoad(startConfigPath, &c)
+	// Initialize application timezone
+	if err := timeutil.LoadLocation(c.AppLocation); err != nil {
+		logger.Errorf("load app timezone %q failed: %v, falling back to Local", c.AppLocation, err)
+	}
 	if !c.Debug {
 		hertzx.SetMode(hertzx.ReleaseMode)
 	}

--- a/initialize/migrate/database/mysql/02132_system_log_date_idx.down.sql
+++ b/initialize/migrate/database/mysql/02132_system_log_date_idx.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX idx_date ON system_logs;

--- a/initialize/migrate/database/mysql/02132_system_log_date_idx.up.sql
+++ b/initialize/migrate/database/mysql/02132_system_log_date_idx.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_date ON system_logs (date);

--- a/initialize/migrate/database/mysql/02133_system_log_fulltext.down.sql
+++ b/initialize/migrate/database/mysql/02133_system_log_fulltext.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE system_logs DROP INDEX ft_content;

--- a/initialize/migrate/database/mysql/02133_system_log_fulltext.up.sql
+++ b/initialize/migrate/database/mysql/02133_system_log_fulltext.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE system_logs ADD FULLTEXT INDEX ft_content (content);

--- a/initialize/migrate/database/postgres/02132_system_log_date_idx.down.sql
+++ b/initialize/migrate/database/postgres/02132_system_log_date_idx.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_date;

--- a/initialize/migrate/database/postgres/02132_system_log_date_idx.up.sql
+++ b/initialize/migrate/database/postgres/02132_system_log_date_idx.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_date ON system_logs (date);

--- a/initialize/migrate/database/postgres/02133_system_log_fulltext.down.sql
+++ b/initialize/migrate/database/postgres/02133_system_log_fulltext.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_content_gin;

--- a/initialize/migrate/database/postgres/02133_system_log_fulltext.up.sql
+++ b/initialize/migrate/database/postgres/02133_system_log_fulltext.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_content_gin ON system_logs USING GIN (to_tsvector('simple', content));

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	Host          string          `yaml:"Host" default:"0.0.0.0"`
 	Port          int             `yaml:"Port" default:"8080"`
 	Debug         bool            `yaml:"Debug" default:"false"`
+	AppLocation   string          `yaml:"AppLocation" default:"Asia/Shanghai"`
 	Transport     TransportConfig `yaml:"Transport"`
 	TLS           TLS             `yaml:"TLS"`
 	JwtAuth       JwtAuth         `yaml:"JwtAuth"`

--- a/internal/logic/admin/application/previewSubscribeTemplateLogic.go
+++ b/internal/logic/admin/application/previewSubscribeTemplateLogic.go
@@ -2,13 +2,13 @@ package application
 
 import (
 	"context"
-	"time"
 
 	"github.com/perfect-panel/server/adapter"
 	"github.com/perfect-panel/server/internal/model/node"
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/internal/types"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/xerr"
 	"github.com/pkg/errors"
 )
@@ -53,7 +53,7 @@ func (l *PreviewSubscribeTemplateLogic) PreviewSubscribeTemplate(req *types.Prev
 		adapter.WithOutputFormat(data.OutputFormat),
 		adapter.WithUserInfo(adapter.User{
 			Password:     "test-password",
-			ExpiredAt:    time.Now().AddDate(1, 0, 0),
+			ExpiredAt:    timeutil.Now().AddDate(1, 0, 0),
 			Download:     0,
 			Upload:       0,
 			Traffic:      1000,

--- a/internal/logic/admin/console/queryRevenueStatisticsLogic.go
+++ b/internal/logic/admin/console/queryRevenueStatisticsLogic.go
@@ -10,6 +10,7 @@ import (
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/internal/types"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/xerr"
 	"github.com/pkg/errors"
 )
@@ -47,7 +48,7 @@ func (l *QueryRevenueStatisticsLogic) QueryRevenueStatistics() (resp *types.Reve
 	}
 
 	var today, monthly, all types.OrdersStatistics
-	now := time.Now()
+	now := timeutil.Now()
 	// Get today's revenue statistics
 	todayData, err := l.svcCtx.Store.Order().QueryDateOrders(l.ctx, now)
 	if err != nil {
@@ -140,7 +141,7 @@ func (l *QueryRevenueStatisticsLogic) QueryRevenueStatistics() (resp *types.Reve
 
 // mockRevenueStatistics is a mock function to simulate revenue statistics data.
 func (l *QueryRevenueStatisticsLogic) mockRevenueStatistics() *types.RevenueStatisticsResponse {
-	now := time.Now()
+	now := timeutil.Now()
 
 	// Generate daily data for the current month (from 1st to current date)
 	monthlyList := make([]types.OrdersStatistics, 7)

--- a/internal/logic/admin/console/queryServerTotalDataLogic.go
+++ b/internal/logic/admin/console/queryServerTotalDataLogic.go
@@ -14,6 +14,7 @@ import (
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/internal/types"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/xerr"
 	"github.com/pkg/errors"
 )
@@ -51,7 +52,7 @@ func (l *QueryServerTotalDataLogic) QueryServerTotalData() (resp *types.ServerTo
 		}
 	}
 
-	now := time.Now()
+	now := timeutil.Now()
 	todayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 	todayEnd := todayStart.Add(24 * time.Hour)
 	trafficStore := l.svcCtx.Store.TrafficLog()
@@ -296,7 +297,7 @@ func (l *QueryServerTotalDataLogic) QueryServerTotalData() (resp *types.ServerTo
 }
 
 func (l *QueryServerTotalDataLogic) mockRevenueStatistics() *types.ServerTotalDataResponse {
-	now := time.Now()
+	now := timeutil.Now()
 
 	// Generate server traffic ranking data for today (top 10)
 	serverTrafficToday := make([]types.ServerTrafficData, 10)

--- a/internal/logic/admin/console/queryUserStatisticsLogic.go
+++ b/internal/logic/admin/console/queryUserStatisticsLogic.go
@@ -10,6 +10,7 @@ import (
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/internal/types"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 )
 
 const consoleUserStatisticsCacheKey = "console:user_statistics"
@@ -45,7 +46,7 @@ func (l *QueryUserStatisticsLogic) QueryUserStatistics() (resp *types.UserStatis
 	}
 
 	resp = &types.UserStatisticsResponse{}
-	now := time.Now()
+	now := timeutil.Now()
 	// query today user register count
 	todayUserResisterCount, err := l.svcCtx.Store.User().QueryResisterUserTotalByDate(l.ctx, now)
 	if err != nil {
@@ -139,7 +140,7 @@ func (l *QueryUserStatisticsLogic) QueryUserStatistics() (resp *types.UserStatis
 }
 
 func (l *QueryUserStatisticsLogic) mockRevenueStatistics() *types.UserStatisticsResponse {
-	now := time.Now()
+	now := timeutil.Now()
 
 	// Generate daily user statistics for the current month (from 1st to current date)
 	monthlyList := make([]types.UserStatistics, 7)

--- a/internal/logic/admin/coupon/createCouponLogic.go
+++ b/internal/logic/admin/coupon/createCouponLogic.go
@@ -3,7 +3,6 @@ package coupon
 import (
 	"context"
 	"math/rand"
-	"time"
 
 	"github.com/perfect-panel/server/internal/model/coupon"
 	"github.com/perfect-panel/server/internal/svc"
@@ -11,6 +10,7 @@ import (
 	"github.com/perfect-panel/server/pkg/logger"
 	"github.com/perfect-panel/server/pkg/random"
 	"github.com/perfect-panel/server/pkg/snowflake"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/tool"
 	"github.com/perfect-panel/server/pkg/xerr"
 	"github.com/pkg/errors"
@@ -33,7 +33,7 @@ func NewCreateCouponLogic(ctx context.Context, svcCtx *svc.ServiceContext) *Crea
 
 func (l *CreateCouponLogic) CreateCoupon(req *types.CreateCouponRequest) error {
 	if req.Code == "" {
-		rand.NewSource(time.Now().UnixNano())
+		rand.NewSource(timeutil.Now().UnixNano())
 		sid := snowflake.GetID()
 		req.Code = random.KeyNew(4, 2) + "-" + random.StrToDashedString(random.EncodeBase36(sid))
 	}

--- a/internal/logic/admin/log/filterServerTrafficLogLogic.go
+++ b/internal/logic/admin/log/filterServerTrafficLogLogic.go
@@ -8,6 +8,7 @@ import (
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/internal/types"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/xerr"
 	"github.com/pkg/errors"
 )
@@ -27,13 +28,13 @@ func NewFilterServerTrafficLogLogic(ctx context.Context, svcCtx *svc.ServiceCont
 	}
 }
 func (l *FilterServerTrafficLogLogic) FilterServerTrafficLog(req *types.FilterServerTrafficLogRequest) (resp *types.FilterServerTrafficLogResponse, err error) {
-	today := time.Now().Format("2006-01-02")
+	today := timeutil.Now().Format("2006-01-02")
 	var list []types.ServerTrafficLog
 	var total int64
 
 	if req.Date == today || req.Date == "" {
-		now := time.Now()
-		start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
+		now := timeutil.Now()
+		start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, timeutil.Location())
 		end := start.Add(24 * time.Hour)
 
 		serverTraffic, err := l.svcCtx.Store.TrafficLog().QueryServerTrafficRanking(l.ctx, start, end)

--- a/internal/logic/admin/log/filterTrafficLogDetailsLogic.go
+++ b/internal/logic/admin/log/filterTrafficLogDetailsLogic.go
@@ -8,6 +8,7 @@ import (
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/internal/types"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/xerr"
 	"github.com/pkg/errors"
 )
@@ -30,7 +31,7 @@ func NewFilterTrafficLogDetailsLogic(ctx context.Context, svcCtx *svc.ServiceCon
 func (l *FilterTrafficLogDetailsLogic) FilterTrafficLogDetails(req *types.FilterTrafficLogDetailsRequest) (resp *types.FilterTrafficLogDetailsResponse, err error) {
 	var start, end time.Time
 	if req.Date != "" {
-		day, err := time.ParseInLocation("2006-01-02", req.Date, time.Local)
+		day, err := time.ParseInLocation("2006-01-02", req.Date, timeutil.Location())
 		if err != nil {
 			l.Errorw("[FilterTrafficLogDetails] Date Parse Error", logger.Field("error", err.Error()))
 			return nil, errors.Wrapf(xerr.NewErrCode(xerr.InvalidParams), " date parse error: %s", err.Error())
@@ -39,7 +40,7 @@ func (l *FilterTrafficLogDetailsLogic) FilterTrafficLogDetails(req *types.Filter
 		end = day.Add(24 * time.Hour)
 	} else {
 		// query today
-		now := time.Now()
+		now := timeutil.Now()
 		start = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 		end = start.Add(24 * time.Hour)
 	}

--- a/internal/logic/admin/log/filterUserSubscribeTrafficLogLogic.go
+++ b/internal/logic/admin/log/filterUserSubscribeTrafficLogLogic.go
@@ -8,6 +8,7 @@ import (
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/internal/types"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/xerr"
 	"github.com/pkg/errors"
 )
@@ -35,13 +36,13 @@ func (l *FilterUserSubscribeTrafficLogLogic) FilterUserSubscribeTrafficLog(req *
 		req.Page = 1
 	}
 
-	today := time.Now().Format("2006-01-02")
+	today := timeutil.Now().Format("2006-01-02")
 	var list []types.UserSubscribeTrafficLog
 	var total int64
 
 	if req.Date == today || req.Date == "" {
-		now := time.Now()
-		start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
+		now := timeutil.Now()
+		start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, timeutil.Location())
 		end := start.Add(24 * time.Hour)
 
 		userTraffic, err := l.svcCtx.Store.TrafficLog().QueryUserTrafficRanking(l.ctx, start, end)

--- a/internal/logic/admin/marketing/createBatchSendEmailTaskLogic.go
+++ b/internal/logic/admin/marketing/createBatchSendEmailTaskLogic.go
@@ -12,6 +12,7 @@ import (
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/internal/types"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/tool"
 	"github.com/perfect-panel/server/pkg/xerr"
 	types2 "github.com/perfect-panel/server/queue/types"
@@ -62,11 +63,11 @@ func (l *CreateBatchSendEmailTaskLogic) CreateBatchSendEmailTask(req *types.Crea
 		return xerr.NewErrMsg("No additional email addresses provided for skip scope")
 	}
 
-	scheduledAt := time.Now().Add(10 * time.Second) // 默认延迟10秒执行,防止任务创建和执行时间过于接近
+	scheduledAt := timeutil.Now().Add(10 * time.Second) // 默认延迟10秒执行,防止任务创建和执行时间过于接近
 	if req.Scheduled != 0 {
 		scheduledAt = time.Unix(req.Scheduled, 0)
-		if scheduledAt.Before(time.Now()) {
-			scheduledAt = time.Now()
+		if scheduledAt.Before(timeutil.Now()) {
+			scheduledAt = timeutil.Now()
 		}
 	}
 

--- a/internal/logic/admin/subscribe/resetAllSubscribeTokenLogic.go
+++ b/internal/logic/admin/subscribe/resetAllSubscribeTokenLogic.go
@@ -3,9 +3,9 @@ package subscribe
 import (
 	"context"
 	"strconv"
-	"time"
 
 	"github.com/perfect-panel/server/internal/repository"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/uuidx"
 	"github.com/perfect-panel/server/pkg/xerr"
 	"github.com/pkg/errors"
@@ -39,7 +39,7 @@ func (l *ResetAllSubscribeTokenLogic) ResetAllSubscribeToken() (resp *types.Rese
 			return errors.Wrapf(xerr.NewErrCode(xerr.DatabaseQueryError), "Failed to fetch subscribe list: %v", err.Error())
 		}
 		for _, sub := range list {
-			sub.Token = uuidx.SubscribeToken(strconv.FormatInt(time.Now().UnixMilli(), 10) + strconv.FormatInt(sub.Id, 10))
+			sub.Token = uuidx.SubscribeToken(strconv.FormatInt(timeutil.Now().UnixMilli(), 10) + strconv.FormatInt(sub.Id, 10))
 			sub.UUID = uuidx.NewUUID().String()
 			if updateErr := store.User().UpdateSubscribe(l.ctx, sub); updateErr != nil {
 				logger.Errorf("[ResetAllSubscribeToken] Failed to update subscribe token for ID %d: %v", sub.Id, updateErr.Error())

--- a/internal/logic/admin/system/preViewNodeMultiplierLogic.go
+++ b/internal/logic/admin/system/preViewNodeMultiplierLogic.go
@@ -2,10 +2,11 @@ package system
 
 import (
 	"context"
+
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/internal/types"
 	"github.com/perfect-panel/server/pkg/logger"
-	"time"
+	"github.com/perfect-panel/server/pkg/timeutil"
 )
 
 type PreViewNodeMultiplierLogic struct {
@@ -24,7 +25,7 @@ func NewPreViewNodeMultiplierLogic(ctx context.Context, svcCtx *svc.ServiceConte
 }
 
 func (l *PreViewNodeMultiplierLogic) PreViewNodeMultiplier() (resp *types.PreViewNodeMultiplierResponse, err error) {
-	now := time.Now()
+	now := timeutil.Now()
 	ratio := l.svcCtx.NodeMultiplierManager.GetMultiplier(now)
 	return &types.PreViewNodeMultiplierResponse{
 		Ratio:       ratio,

--- a/internal/logic/admin/user/createUserLogic.go
+++ b/internal/logic/admin/user/createUserLogic.go
@@ -3,12 +3,12 @@ package user
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/perfect-panel/server/internal/model/user"
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/internal/types"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/tool"
 	"github.com/perfect-panel/server/pkg/uuidx"
 	"github.com/perfect-panel/server/pkg/xerr"
@@ -32,7 +32,7 @@ func NewCreateUserLogic(ctx context.Context, svcCtx *svc.ServiceContext) *Create
 func (l *CreateUserLogic) CreateUser(req *types.CreateUserRequest) error {
 	if req.ReferCode == "" {
 		// timestamp replaces user id
-		req.ReferCode = uuidx.UserInviteCode(time.Now().UnixMicro())
+		req.ReferCode = uuidx.UserInviteCode(timeutil.Now().UnixMicro())
 	}
 	if req.Password == "" {
 		req.Password = req.Email

--- a/internal/logic/admin/user/createUserSubscribeLogic.go
+++ b/internal/logic/admin/user/createUserSubscribeLogic.go
@@ -10,6 +10,7 @@ import (
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/internal/types"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/uuidx"
 	"github.com/perfect-panel/server/pkg/xerr"
 	"github.com/pkg/errors"
@@ -57,12 +58,12 @@ func (l *CreateUserSubscribeLogic) CreateUserSubscribe(req *types.CreateUserSubs
 	userSub := user.Subscribe{
 		UserId:      req.UserId,
 		SubscribeId: req.SubscribeId,
-		StartTime:   time.Now(),
+		StartTime:   timeutil.Now(),
 		ExpireTime:  time.UnixMilli(req.ExpiredAt),
 		Traffic:     req.Traffic,
 		Download:    0,
 		Upload:      0,
-		Token:       uuidx.SubscribeToken(fmt.Sprintf("adminCreate:%d", time.Now().UnixMilli())),
+		Token:       uuidx.SubscribeToken(fmt.Sprintf("adminCreate:%d", timeutil.Now().UnixMilli())),
 		UUID:        uuid.New().String(),
 		Status:      1,
 	}

--- a/internal/logic/admin/user/getUserSubscribeLogsLogic.go
+++ b/internal/logic/admin/user/getUserSubscribeLogsLogic.go
@@ -2,12 +2,12 @@ package user
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/perfect-panel/server/internal/model/log"
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/internal/types"
 	"github.com/perfect-panel/server/pkg/logger"
-	"github.com/perfect-panel/server/pkg/tool"
 	"github.com/perfect-panel/server/pkg/xerr"
 	"github.com/pkg/errors"
 )
@@ -28,14 +28,40 @@ func NewGetUserSubscribeLogsLogic(ctx context.Context, svcCtx *svc.ServiceContex
 }
 
 func (l *GetUserSubscribeLogsLogic) GetUserSubscribeLogs(req *types.GetUserSubscribeLogsRequest) (resp *types.GetUserSubscribeLogsResponse, err error) {
-	data, total, err := l.svcCtx.Store.Log().FilterSystemLog(l.ctx, &log.FilterParams{})
+	params := &log.FilterParams{
+		Page:     req.Page,
+		Size:     req.Size,
+		Type:     log.TypeSubscribe.Uint8(),
+		ObjectID: req.UserId,
+	}
+	if req.SubscribeId != 0 {
+		params.Search = `"user_subscribe_id":` + strconv.FormatInt(req.SubscribeId, 10)
+	}
+
+	data, total, err := l.svcCtx.Store.Log().FilterSystemLog(l.ctx, params)
 
 	if err != nil {
 		l.Errorw("[GetUserSubscribeLogs] Get User Subscribe Logs Error:", logger.Field("err", err.Error()))
 		return nil, errors.Wrapf(xerr.NewErrCode(xerr.DatabaseQueryError), "Get User Subscribe Logs Error")
 	}
 	var list []types.UserSubscribeLog
-	tool.DeepCopy(&list, data)
+
+	for _, datum := range data {
+		var content log.Subscribe
+		if err = content.Unmarshal([]byte(datum.Content)); err != nil {
+			l.Errorf("[GetUserSubscribeLogs] unmarshal subscribe log content failed: %v", err.Error())
+			continue
+		}
+		list = append(list, types.UserSubscribeLog{
+			Id:              datum.Id,
+			UserId:          datum.ObjectID,
+			UserSubscribeId: content.UserSubscribeId,
+			Token:           content.Token,
+			IP:              content.ClientIP,
+			UserAgent:       content.UserAgent,
+			Timestamp:       datum.CreatedAt.UnixMilli(),
+		})
+	}
 
 	return &types.GetUserSubscribeLogsResponse{
 		List:  list,

--- a/internal/logic/admin/user/resetUserSubscribeTokenLogic.go
+++ b/internal/logic/admin/user/resetUserSubscribeTokenLogic.go
@@ -3,11 +3,11 @@ package user
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/internal/types"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/uuidx"
 	"github.com/perfect-panel/server/pkg/xerr"
 	"github.com/pkg/errors"
@@ -34,7 +34,7 @@ func (l *ResetUserSubscribeTokenLogic) ResetUserSubscribeToken(req *types.ResetU
 		logger.Errorf("[ResetUserSubscribeToken] FindOneSubscribe error: %v", err.Error())
 		return errors.Wrapf(xerr.NewErrCode(xerr.DatabaseQueryError), "FindOneSubscribe error: %v", err.Error())
 	}
-	userSub.Token = uuidx.SubscribeToken(fmt.Sprintf("AdminUpdate:%d", time.Now().UnixMilli()))
+	userSub.Token = uuidx.SubscribeToken(fmt.Sprintf("AdminUpdate:%d", timeutil.Now().UnixMilli()))
 
 	err = l.svcCtx.Store.User().UpdateSubscribe(l.ctx, userSub)
 	if err != nil {

--- a/internal/logic/admin/user/updateUserBasicInfoLogic.go
+++ b/internal/logic/admin/user/updateUserBasicInfoLogic.go
@@ -10,6 +10,7 @@ import (
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/internal/types"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/tool"
 	"github.com/perfect-panel/server/pkg/xerr"
 	"github.com/pkg/errors"
@@ -50,13 +51,13 @@ func (l *UpdateUserBasicInfoLogic) UpdateUserBasicInfo(req *types.UpdateUserBasi
 			Amount:    change,
 			OrderNo:   "",
 			Balance:   req.Balance,
-			Timestamp: time.Now().UnixMilli(),
+			Timestamp: timeutil.Now().UnixMilli(),
 		}
 		content, _ := balanceLog.Marshal()
 
 		err = l.svcCtx.Store.Log().Insert(l.ctx, &log.SystemLog{
 			Type:     log.TypeBalance.Uint8(),
-			Date:     time.Now().Format(time.DateOnly),
+			Date:     timeutil.Now().Format(time.DateOnly),
 			ObjectID: userInfo.Id,
 			Content:  string(content),
 		})
@@ -80,13 +81,13 @@ func (l *UpdateUserBasicInfoLogic) UpdateUserBasicInfo(req *types.UpdateUserBasi
 				Amount:    change,
 				Balance:   req.GiftAmount,
 				Remark:    "Admin adjustment",
-				Timestamp: time.Now().UnixMilli(),
+				Timestamp: timeutil.Now().UnixMilli(),
 			}
 			content, _ := giftLog.Marshal()
 			// Add gift amount change log
 			err = l.svcCtx.Store.Log().Insert(l.ctx, &log.SystemLog{
 				Type:     log.TypeGift.Uint8(),
-				Date:     time.Now().Format(time.DateOnly),
+				Date:     timeutil.Now().Format(time.DateOnly),
 				ObjectID: userInfo.Id,
 				Content:  string(content),
 			})
@@ -102,13 +103,13 @@ func (l *UpdateUserBasicInfoLogic) UpdateUserBasicInfo(req *types.UpdateUserBasi
 		commentLog := log.Commission{
 			Type:      log.CommissionTypeAdjust,
 			Amount:    req.Commission - userInfo.Commission,
-			Timestamp: time.Now().UnixMilli(),
+			Timestamp: timeutil.Now().UnixMilli(),
 		}
 
 		content, _ := commentLog.Marshal()
 		err = l.svcCtx.Store.Log().Insert(l.ctx, &log.SystemLog{
 			Type:     log.TypeCommission.Uint8(),
-			Date:     time.Now().Format(time.DateOnly),
+			Date:     timeutil.Now().Format(time.DateOnly),
 			ObjectID: userInfo.Id,
 			Content:  string(content),
 		})

--- a/internal/logic/auth/deviceLoginLogic.go
+++ b/internal/logic/auth/deviceLoginLogic.go
@@ -13,6 +13,7 @@ import (
 	"github.com/perfect-panel/server/internal/types"
 	"github.com/perfect-panel/server/pkg/jwt"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/tool"
 	"github.com/perfect-panel/server/pkg/uuidx"
 	"github.com/perfect-panel/server/pkg/xerr"
@@ -50,12 +51,12 @@ func (l *DeviceLoginLogic) DeviceLogin(req *types.DeviceLoginRequest) (resp *typ
 				LoginIP:   req.IP,
 				UserAgent: req.UserAgent,
 				Success:   loginStatus,
-				Timestamp: time.Now().UnixMilli(),
+				Timestamp: timeutil.Now().UnixMilli(),
 			}
 			content, _ := loginLog.Marshal()
 			if err := l.svcCtx.Store.Log().Insert(l.ctx, &log.SystemLog{
 				Type:     log.TypeLogin.Uint8(),
-				Date:     time.Now().Format("2006-01-02"),
+				Date:     timeutil.Now().Format("2006-01-02"),
 				ObjectID: userInfo.Id,
 				Content:  string(content),
 			}); err != nil {
@@ -102,7 +103,7 @@ func (l *DeviceLoginLogic) DeviceLogin(req *types.DeviceLoginRequest) (resp *typ
 	// Generate token
 	token, err := jwt.NewJwtToken(
 		l.svcCtx.Config.JwtAuth.AccessSecret,
-		time.Now().Unix(),
+		timeutil.Now().Unix(),
 		l.svcCtx.Config.JwtAuth.AccessExpire,
 		jwt.WithOption("UserId", userInfo.Id),
 		jwt.WithOption("SessionId", sessionId),
@@ -229,13 +230,13 @@ func (l *DeviceLoginLogic) registerUserAndDevice(req *types.DeviceLoginRequest) 
 		Identifier: req.Identifier,
 		RegisterIP: req.IP,
 		UserAgent:  req.UserAgent,
-		Timestamp:  time.Now().UnixMilli(),
+		Timestamp:  timeutil.Now().UnixMilli(),
 	}
 	content, _ := registerLog.Marshal()
 
 	if err := l.svcCtx.Store.Log().Insert(l.ctx, &log.SystemLog{
 		Type:     log.TypeRegister.Uint8(),
-		Date:     time.Now().Format("2006-01-02"),
+		Date:     timeutil.Now().Format("2006-01-02"),
 		ObjectID: userInfo.Id,
 		Content:  string(content),
 	}); err != nil {
@@ -260,7 +261,7 @@ func (l *DeviceLoginLogic) activeTrial(store repository.Store, userId int64) (*u
 		return nil, err
 	}
 
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	expireTime := tool.AddTime(l.svcCtx.Config.Register.TrialTimeUnit, l.svcCtx.Config.Register.TrialTime, startTime)
 	subscribeToken := uuidx.SubscribeToken(fmt.Sprintf("Trial-%v-%s", userId, uuidx.NewUUID().String()))
 	subscribeUUID := uuidx.NewUUID().String()

--- a/internal/logic/auth/oauth/oAuthLoginGetTokenLogic.go
+++ b/internal/logic/auth/oauth/oAuthLoginGetTokenLogic.go
@@ -18,6 +18,7 @@ import (
 	"github.com/perfect-panel/server/pkg/oauth/apple"
 	"github.com/perfect-panel/server/pkg/oauth/google"
 	"github.com/perfect-panel/server/pkg/oauth/telegram"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/tool"
 	"github.com/perfect-panel/server/pkg/uuidx"
 	"github.com/perfect-panel/server/pkg/xerr"
@@ -84,7 +85,7 @@ func (l *OAuthLoginGetTokenLogic) OAuthLoginGetToken(req *types.OAuthLoginGetTok
 }
 
 func (l *OAuthLoginGetTokenLogic) google(req *types.OAuthLoginGetTokenRequest, requestID, ip, userAgent string) (*user.User, error) {
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	l.Infow("google oauth processing started",
 		logger.Field("request_id", requestID),
 		logger.Field("provider", OAuthGoogle),
@@ -162,7 +163,7 @@ func (l *OAuthLoginGetTokenLogic) google(req *types.OAuthLoginGetTokenRequest, r
 }
 
 func (l *OAuthLoginGetTokenLogic) apple(req *types.OAuthLoginGetTokenRequest, requestID, ip, userAgent string) (*user.User, error) {
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	l.Infow("apple oauth processing started",
 		logger.Field("request_id", requestID),
 		logger.Field("provider", OAuthApple),
@@ -262,7 +263,7 @@ func (l *OAuthLoginGetTokenLogic) apple(req *types.OAuthLoginGetTokenRequest, re
 }
 
 func (l *OAuthLoginGetTokenLogic) telegram(req *types.OAuthLoginGetTokenRequest, requestID, ip, userAgent string) (*user.User, error) {
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	l.Infow("telegram oauth processing started",
 		logger.Field("request_id", requestID),
 		logger.Field("provider", OAuthTelegram),
@@ -292,15 +293,15 @@ func (l *OAuthLoginGetTokenLogic) telegram(req *types.OAuthLoginGetTokenRequest,
 	l.Debugw("validating telegram auth date",
 		logger.Field("request_id", requestID),
 		logger.Field("auth_date", *callbackData.AuthDate),
-		logger.Field("current_time", time.Now().Unix()),
+		logger.Field("current_time", timeutil.Now().Unix()),
 	)
 
-	if time.Now().Unix()-*callbackData.AuthDate > AuthExpire {
+	if timeutil.Now().Unix()-*callbackData.AuthDate > AuthExpire {
 		l.Errorw("telegram auth date expired",
 			logger.Field("request_id", requestID),
 			logger.Field("provider", OAuthTelegram),
 			logger.Field("auth_date", *callbackData.AuthDate),
-			logger.Field("current_time", time.Now().Unix()),
+			logger.Field("current_time", timeutil.Now().Unix()),
 			logger.Field("expire_seconds", AuthExpire),
 		)
 		return nil, errors.Wrapf(xerr.NewErrCode(xerr.ERROR), "auth date expired")
@@ -325,7 +326,7 @@ func (l *OAuthLoginGetTokenLogic) telegram(req *types.OAuthLoginGetTokenRequest,
 }
 
 func (l *OAuthLoginGetTokenLogic) register(email, avatar, method, openid, requestID, ip, userAgent string) (*user.User, error) {
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	l.Infow("user registration started",
 		logger.Field("request_id", requestID),
 		logger.Field("auth_method", method),
@@ -435,13 +436,13 @@ func (l *OAuthLoginGetTokenLogic) register(email, avatar, method, openid, reques
 		Identifier: openid,
 		RegisterIP: ip,
 		UserAgent:  userAgent,
-		Timestamp:  time.Now().UnixMilli(),
+		Timestamp:  timeutil.Now().UnixMilli(),
 	}
 	content, _ := registerLog.Marshal()
 
 	err = l.svcCtx.Store.Log().Insert(l.ctx, &log.SystemLog{
 		Type:     log.TypeRegister.Uint8(),
-		Date:     time.Now().Format("2006-01-02"),
+		Date:     timeutil.Now().Format("2006-01-02"),
 		ObjectID: userInfo.Id,
 		Content:  string(content),
 	})
@@ -524,12 +525,12 @@ func (l *OAuthLoginGetTokenLogic) recordLoginStatus(loginStatus bool, userInfo *
 			LoginIP:   ip,
 			UserAgent: userAgent,
 			Success:   loginStatus,
-			Timestamp: time.Now().UnixMilli(),
+			Timestamp: timeutil.Now().UnixMilli(),
 		}
 		content, _ := loginLog.Marshal()
 		if err := l.svcCtx.Store.Log().Insert(l.ctx, &log.SystemLog{
 			Type:     log.TypeLogin.Uint8(),
-			Date:     time.Now().Format("2006-01-02"),
+			Date:     timeutil.Now().Format("2006-01-02"),
 			ObjectID: userInfo.Id,
 			Content:  string(content),
 		}); err != nil {
@@ -566,7 +567,7 @@ func (l *OAuthLoginGetTokenLogic) handleOAuthProvider(req *types.OAuthLoginGetTo
 }
 
 func (l *OAuthLoginGetTokenLogic) generateToken(userInfo *user.User, requestID string) (string, error) {
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	sessionId := uuidx.NewUUID().String()
 
 	l.Debugw("generating jwt token",
@@ -577,7 +578,7 @@ func (l *OAuthLoginGetTokenLogic) generateToken(userInfo *user.User, requestID s
 
 	token, err := jwt.NewJwtToken(
 		l.svcCtx.Config.JwtAuth.AccessSecret,
-		time.Now().Unix(),
+		timeutil.Now().Unix(),
 		l.svcCtx.Config.JwtAuth.AccessExpire,
 		jwt.WithOption("UserId", userInfo.Id),
 		jwt.WithOption("SessionId", sessionId),
@@ -815,7 +816,7 @@ func (l *OAuthLoginGetTokenLogic) activeTrial(store repository.Store, uid int64,
 		return nil, err
 	}
 
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	expireTime := tool.AddTime(l.svcCtx.Config.Register.TrialTimeUnit, l.svcCtx.Config.Register.TrialTime, startTime)
 	subscribeToken := uuidx.SubscribeToken(fmt.Sprintf("Trial-%v-%s", uid, uuidx.NewUUID().String()))
 	subscribeUUID := uuidx.NewUUID().String()

--- a/internal/logic/auth/resetPasswordLogic.go
+++ b/internal/logic/auth/resetPasswordLogic.go
@@ -9,6 +9,7 @@ import (
 	"github.com/perfect-panel/server/internal/model/log"
 	"github.com/perfect-panel/server/internal/model/user"
 	"github.com/perfect-panel/server/pkg/jwt"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/uuidx"
 
 	"github.com/perfect-panel/server/internal/config"
@@ -49,13 +50,13 @@ func (l *ResetPasswordLogic) ResetPassword(req *types.ResetPasswordRequest) (res
 				LoginIP:   req.IP,
 				UserAgent: req.UserAgent,
 				Success:   loginStatus,
-				Timestamp: time.Now().UnixMilli(),
+				Timestamp: timeutil.Now().UnixMilli(),
 			}
 			content, _ := loginLog.Marshal()
 			if err := l.svcCtx.Store.Log().Insert(l.ctx, &log.SystemLog{
 				Id:       0,
 				Type:     log.TypeLogin.Uint8(),
-				Date:     time.Now().Format("2006-01-02"),
+				Date:     timeutil.Now().Format("2006-01-02"),
 				ObjectID: userInfo.Id,
 				Content:  string(content),
 			}); err != nil {
@@ -129,7 +130,7 @@ func (l *ResetPasswordLogic) ResetPassword(req *types.ResetPasswordRequest) (res
 	// Generate token
 	token, err := jwt.NewJwtToken(
 		l.svcCtx.Config.JwtAuth.AccessSecret,
-		time.Now().Unix(),
+		timeutil.Now().Unix(),
 		l.svcCtx.Config.JwtAuth.AccessExpire,
 		jwt.WithOption("UserId", userInfo.Id),
 		jwt.WithOption("SessionId", sessionId),

--- a/internal/logic/auth/telephoneLoginLogic.go
+++ b/internal/logic/auth/telephoneLoginLogic.go
@@ -16,6 +16,7 @@ import (
 	"github.com/perfect-panel/server/pkg/jwt"
 	"github.com/perfect-panel/server/pkg/logger"
 	"github.com/perfect-panel/server/pkg/phone"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/tool"
 	"github.com/perfect-panel/server/pkg/uuidx"
 	"github.com/perfect-panel/server/pkg/xerr"
@@ -72,13 +73,13 @@ func (l *TelephoneLoginLogic) TelephoneLogin(req *types.TelephoneLoginRequest, r
 				LoginIP:   ip,
 				UserAgent: r.UserAgent(),
 				Success:   loginStatus,
-				Timestamp: time.Now().UnixMilli(),
+				Timestamp: timeutil.Now().UnixMilli(),
 			}
 			content, _ := loginLog.Marshal()
 			if err := l.svcCtx.Store.Log().Insert(l.ctx, &log.SystemLog{
 				Id:       0,
 				Type:     log.TypeLogin.Uint8(),
-				Date:     time.Now().Format("2006-01-02"),
+				Date:     timeutil.Now().Format("2006-01-02"),
 				ObjectID: userInfo.Id,
 				Content:  string(content),
 			}); err != nil {
@@ -145,7 +146,7 @@ func (l *TelephoneLoginLogic) TelephoneLogin(req *types.TelephoneLoginRequest, r
 	// Generate token
 	token, err := jwt.NewJwtToken(
 		l.svcCtx.Config.JwtAuth.AccessSecret,
-		time.Now().Unix(),
+		timeutil.Now().Unix(),
 		l.svcCtx.Config.JwtAuth.AccessExpire,
 		jwt.WithOption("UserId", userInfo.Id),
 		jwt.WithOption("SessionId", sessionId),

--- a/internal/logic/auth/telephoneResetPasswordLogic.go
+++ b/internal/logic/auth/telephoneResetPasswordLogic.go
@@ -13,6 +13,7 @@ import (
 	"github.com/perfect-panel/server/pkg/jwt"
 	"github.com/perfect-panel/server/pkg/logger"
 	"github.com/perfect-panel/server/pkg/phone"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/tool"
 	"github.com/perfect-panel/server/pkg/uuidx"
 	"github.com/perfect-panel/server/pkg/xerr"
@@ -104,7 +105,7 @@ func (l *TelephoneResetPasswordLogic) TelephoneResetPassword(req *types.Telephon
 	// Generate token
 	token, err := jwt.NewJwtToken(
 		l.svcCtx.Config.JwtAuth.AccessSecret,
-		time.Now().Unix(),
+		timeutil.Now().Unix(),
 		l.svcCtx.Config.JwtAuth.AccessExpire,
 		jwt.WithOption("UserId", userInfo.Id),
 		jwt.WithOption("SessionId", sessionId),
@@ -125,13 +126,13 @@ func (l *TelephoneResetPasswordLogic) TelephoneResetPassword(req *types.Telephon
 				LoginIP:   req.IP,
 				UserAgent: req.UserAgent,
 				Success:   token != "",
-				Timestamp: time.Now().UnixMilli(),
+				Timestamp: timeutil.Now().UnixMilli(),
 			}
 			content, _ := loginLog.Marshal()
 			if err := l.svcCtx.Store.Log().Insert(l.ctx, &log.SystemLog{
 				Id:       0,
 				Type:     log.TypeLogin.Uint8(),
-				Date:     time.Now().Format("2006-01-02"),
+				Date:     timeutil.Now().Format("2006-01-02"),
 				ObjectID: userInfo.Id,
 				Content:  string(content),
 			}); err != nil {

--- a/internal/logic/auth/telephoneUserRegisterLogic.go
+++ b/internal/logic/auth/telephoneUserRegisterLogic.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/perfect-panel/server/internal/model/log"
 	"github.com/perfect-panel/server/pkg/constant"
+	"github.com/perfect-panel/server/pkg/timeutil"
 
 	"github.com/perfect-panel/server/internal/config"
 	"github.com/perfect-panel/server/internal/model/user"
@@ -167,7 +168,7 @@ func (l *TelephoneUserRegisterLogic) TelephoneUserRegister(req *types.TelephoneR
 	// Generate token
 	token, err := jwt.NewJwtToken(
 		l.svcCtx.Config.JwtAuth.AccessSecret,
-		time.Now().Unix(),
+		timeutil.Now().Unix(),
 		l.svcCtx.Config.JwtAuth.AccessExpire,
 		jwt.WithOption("UserId", userInfo.Id),
 		jwt.WithOption("SessionId", sessionId),
@@ -189,13 +190,13 @@ func (l *TelephoneUserRegisterLogic) TelephoneUserRegister(req *types.TelephoneR
 				LoginIP:   req.IP,
 				UserAgent: req.UserAgent,
 				Success:   token != "",
-				Timestamp: time.Now().UnixMilli(),
+				Timestamp: timeutil.Now().UnixMilli(),
 			}
 			content, _ := loginLog.Marshal()
 			if err := l.svcCtx.Store.Log().Insert(l.ctx, &log.SystemLog{
 				Id:       0,
 				Type:     log.TypeLogin.Uint8(),
-				Date:     time.Now().Format("2006-01-02"),
+				Date:     timeutil.Now().Format("2006-01-02"),
 				ObjectID: userInfo.Id,
 				Content:  string(content),
 			}); err != nil {
@@ -212,13 +213,13 @@ func (l *TelephoneUserRegisterLogic) TelephoneUserRegister(req *types.TelephoneR
 				Identifier: phoneNumber,
 				RegisterIP: req.IP,
 				UserAgent:  req.UserAgent,
-				Timestamp:  time.Now().UnixMilli(),
+				Timestamp:  timeutil.Now().UnixMilli(),
 			}
 			content, _ = registerLog.Marshal()
 			if err := l.svcCtx.Store.Log().Insert(l.ctx, &log.SystemLog{
 				Type:     log.TypeRegister.Uint8(),
 				ObjectID: userInfo.Id,
-				Date:     time.Now().Format("2006-01-02"),
+				Date:     timeutil.Now().Format("2006-01-02"),
 				Content:  string(content),
 			}); err != nil {
 				l.Errorw("failed to insert login log",
@@ -243,8 +244,8 @@ func (l *TelephoneUserRegisterLogic) activeTrial(store repository.Store, uid int
 		UserId:      uid,
 		OrderId:     0,
 		SubscribeId: sub.Id,
-		StartTime:   time.Now(),
-		ExpireTime:  tool.AddTime(l.svcCtx.Config.Register.TrialTimeUnit, l.svcCtx.Config.Register.TrialTime, time.Now()),
+		StartTime:   timeutil.Now(),
+		ExpireTime:  tool.AddTime(l.svcCtx.Config.Register.TrialTimeUnit, l.svcCtx.Config.Register.TrialTime, timeutil.Now()),
 		Traffic:     sub.Traffic,
 		Download:    0,
 		Upload:      0,

--- a/internal/logic/auth/userLoginLogic.go
+++ b/internal/logic/auth/userLoginLogic.go
@@ -8,6 +8,7 @@ import (
 	"github.com/perfect-panel/server/internal/model/log"
 	"github.com/perfect-panel/server/pkg/constant"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 
 	"github.com/perfect-panel/server/internal/config"
 	"github.com/perfect-panel/server/internal/model/user"
@@ -48,12 +49,12 @@ func (l *UserLoginLogic) UserLogin(req *types.UserLoginRequest) (resp *types.Log
 				LoginIP:   req.IP,
 				UserAgent: req.UserAgent,
 				Success:   loginStatus,
-				Timestamp: time.Now().UnixMilli(),
+				Timestamp: timeutil.Now().UnixMilli(),
 			}
 			content, _ := loginLog.Marshal()
 			if err := l.svcCtx.Store.Log().Insert(l.ctx, &log.SystemLog{
 				Type:     log.TypeLogin.Uint8(),
-				Date:     time.Now().Format("2006-01-02"),
+				Date:     timeutil.Now().Format("2006-01-02"),
 				ObjectID: userInfo.Id,
 				Content:  string(content),
 			}); err != nil {
@@ -110,7 +111,7 @@ func (l *UserLoginLogic) UserLogin(req *types.UserLoginRequest) (resp *types.Log
 	// Generate token
 	token, err := jwt.NewJwtToken(
 		l.svcCtx.Config.JwtAuth.AccessSecret,
-		time.Now().Unix(),
+		timeutil.Now().Unix(),
 		l.svcCtx.Config.JwtAuth.AccessExpire,
 		jwt.WithOption("UserId", userInfo.Id),
 		jwt.WithOption("SessionId", sessionId),

--- a/internal/logic/auth/userRegisterLogic.go
+++ b/internal/logic/auth/userRegisterLogic.go
@@ -16,6 +16,7 @@ import (
 	"github.com/perfect-panel/server/pkg/constant"
 	"github.com/perfect-panel/server/pkg/jwt"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/tool"
 	"github.com/perfect-panel/server/pkg/uuidx"
 	"github.com/perfect-panel/server/pkg/xerr"
@@ -157,7 +158,7 @@ func (l *UserRegisterLogic) UserRegister(req *types.UserRegisterRequest) (resp *
 	// Generate token
 	token, err := jwt.NewJwtToken(
 		l.svcCtx.Config.JwtAuth.AccessSecret,
-		time.Now().Unix(),
+		timeutil.Now().Unix(),
 		l.svcCtx.Config.JwtAuth.AccessExpire,
 		jwt.WithOption("UserId", userInfo.Id),
 		jwt.WithOption("SessionId", sessionId),
@@ -180,13 +181,13 @@ func (l *UserRegisterLogic) UserRegister(req *types.UserRegisterRequest) (resp *
 				LoginIP:   req.IP,
 				UserAgent: req.UserAgent,
 				Success:   loginStatus,
-				Timestamp: time.Now().UnixMilli(),
+				Timestamp: timeutil.Now().UnixMilli(),
 			}
 			content, _ := loginLog.Marshal()
 			if err := l.svcCtx.Store.Log().Insert(l.ctx, &log.SystemLog{
 				Id:       0,
 				Type:     log.TypeLogin.Uint8(),
-				Date:     time.Now().Format("2006-01-02"),
+				Date:     timeutil.Now().Format("2006-01-02"),
 				ObjectID: userInfo.Id,
 				Content:  string(content),
 			}); err != nil {
@@ -203,13 +204,13 @@ func (l *UserRegisterLogic) UserRegister(req *types.UserRegisterRequest) (resp *
 				Identifier: req.Email,
 				RegisterIP: req.IP,
 				UserAgent:  req.UserAgent,
-				Timestamp:  time.Now().UnixMilli(),
+				Timestamp:  timeutil.Now().UnixMilli(),
 			}
 			content, _ = registerLog.Marshal()
 			if err = l.svcCtx.Store.Log().Insert(l.ctx, &log.SystemLog{
 				Type:     log.TypeRegister.Uint8(),
 				ObjectID: userInfo.Id,
-				Date:     time.Now().Format("2006-01-02"),
+				Date:     timeutil.Now().Format("2006-01-02"),
 				Content:  string(content),
 			}); err != nil {
 				l.Errorw("failed to insert login log",
@@ -233,8 +234,8 @@ func (l *UserRegisterLogic) activeTrial(store repository.Store, uid int64) (*use
 		UserId:      uid,
 		OrderId:     0,
 		SubscribeId: sub.Id,
-		StartTime:   time.Now(),
-		ExpireTime:  tool.AddTime(l.svcCtx.Config.Register.TrialTimeUnit, l.svcCtx.Config.Register.TrialTime, time.Now()),
+		StartTime:   timeutil.Now(),
+		ExpireTime:  tool.AddTime(l.svcCtx.Config.Register.TrialTimeUnit, l.svcCtx.Config.Register.TrialTime, timeutil.Now()),
 		Traffic:     sub.Traffic,
 		Download:    0,
 		Upload:      0,

--- a/internal/logic/common/heartbeatLogic.go
+++ b/internal/logic/common/heartbeatLogic.go
@@ -2,11 +2,11 @@ package common
 
 import (
 	"context"
-	"time"
 
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/internal/types"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 )
 
 type HeartbeatLogic struct {
@@ -28,6 +28,6 @@ func (l *HeartbeatLogic) Heartbeat() (resp *types.HeartbeatResponse, err error) 
 	return &types.HeartbeatResponse{
 		Status:    true,
 		Message:   "service is alive",
-		Timestamp: time.Now().Unix(),
+		Timestamp: timeutil.Now().Unix(),
 	}, nil
 }

--- a/internal/logic/common/sendEmailCodeLogic.go
+++ b/internal/logic/common/sendEmailCodeLogic.go
@@ -11,6 +11,7 @@ import (
 	"github.com/perfect-panel/server/pkg/constant"
 	"github.com/perfect-panel/server/pkg/limit"
 	"github.com/perfect-panel/server/pkg/random"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 
@@ -99,7 +100,7 @@ func (l *SendEmailCodeLogic) SendEmailCode(req *types.SendCodeRequest) (resp *ty
 	// Save to Redis
 	payload = CacheKeyPayload{
 		Code:   code,
-		LastAt: time.Now().Unix(),
+		LastAt: timeutil.Now().Unix(),
 	}
 	// Marshal the payload
 	val, _ := json.Marshal(payload)

--- a/internal/logic/common/sendSmsCodeLogic.go
+++ b/internal/logic/common/sendSmsCodeLogic.go
@@ -15,6 +15,7 @@ import (
 	"github.com/perfect-panel/server/pkg/logger"
 	"github.com/perfect-panel/server/pkg/phone"
 	"github.com/perfect-panel/server/pkg/random"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/xerr"
 	queue "github.com/perfect-panel/server/queue/types"
 	"github.com/pkg/errors"
@@ -87,7 +88,7 @@ func (l *SendSmsCodeLogic) SendSmsCode(req *types.SendSmsCodeRequest) (resp *typ
 	// Save to Redis
 	payload := CacheKeyPayload{
 		Code:   code,
-		LastAt: time.Now().Unix(),
+		LastAt: timeutil.Now().Unix(),
 	}
 	// Marshal the payload
 	val, _ := json.Marshal(payload)

--- a/internal/logic/public/order/closeOrderLogic.go
+++ b/internal/logic/public/order/closeOrderLogic.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/perfect-panel/server/internal/model/log"
 	"github.com/perfect-panel/server/pkg/payment/stripe"
+	"github.com/perfect-panel/server/pkg/timeutil"
 
 	"github.com/perfect-panel/server/internal/model/order"
 	"github.com/perfect-panel/server/internal/model/payment"
@@ -118,14 +119,14 @@ func (l *CloseOrderLogic) CloseOrder(req *types.CloseOrderRequest) error {
 				Amount:      orderInfo.GiftAmount,
 				Balance:     deduction,
 				Remark:      "Order cancellation refund",
-				Timestamp:   time.Now().UnixMilli(),
+				Timestamp:   timeutil.Now().UnixMilli(),
 			}
 			content, _ := giftLog.Marshal()
 
 			err = txStore.Log().Insert(l.ctx, &log.SystemLog{
 				Id:       0,
 				Type:     log.TypeGift.Uint8(),
-				Date:     time.Now().Format(time.DateOnly),
+				Date:     timeutil.Now().Format(time.DateOnly),
 				ObjectID: userInfo.Id,
 				Content:  string(content),
 			})

--- a/internal/logic/public/order/purchaseLogic.go
+++ b/internal/logic/public/order/purchaseLogic.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/perfect-panel/server/internal/model/log"
 	"github.com/perfect-panel/server/pkg/constant"
+	"github.com/perfect-panel/server/pkg/timeutil"
 
 	"github.com/hibiken/asynq"
 	"github.com/perfect-panel/server/internal/model/order"
@@ -249,13 +250,13 @@ func (l *PurchaseLogic) Purchase(req *types.PurchaseOrderRequest) (resp *types.P
 				Amount:      orderInfo.GiftAmount,
 				Balance:     u.GiftAmount,
 				Remark:      "Purchase order deduction",
-				Timestamp:   time.Now().UnixMilli(),
+				Timestamp:   timeutil.Now().UnixMilli(),
 			}
 			content, _ := giftLog.Marshal()
 
 			if e := txStore.Log().Insert(l.ctx, &log.SystemLog{
 				Type:     log.TypeGift.Uint8(),
-				Date:     time.Now().Format(time.DateOnly),
+				Date:     timeutil.Now().Format(time.DateOnly),
 				ObjectID: u.Id,
 				Content:  string(content),
 			}); e != nil {

--- a/internal/logic/public/order/renewalLogic.go
+++ b/internal/logic/public/order/renewalLogic.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/perfect-panel/server/internal/model/log"
 	"github.com/perfect-panel/server/pkg/constant"
+	"github.com/perfect-panel/server/pkg/timeutil"
 
 	"github.com/hibiken/asynq"
 	"github.com/perfect-panel/server/internal/model/order"
@@ -198,13 +199,13 @@ func (l *RenewalLogic) Renewal(req *types.RenewalOrderRequest) (resp *types.Rene
 				Amount:      orderInfo.GiftAmount,
 				Balance:     u.GiftAmount,
 				Remark:      "Renewal order deduction",
-				Timestamp:   time.Now().UnixMilli(),
+				Timestamp:   timeutil.Now().UnixMilli(),
 			}
 			content, _ := giftLog.Marshal()
 
 			if err := txStore.Log().Insert(l.ctx, &log.SystemLog{
 				Type:     log.TypeGift.Uint8(),
-				Date:     time.Now().Format(time.DateOnly),
+				Date:     timeutil.Now().Format(time.DateOnly),
 				ObjectID: u.Id,
 				Content:  string(content),
 			}); err != nil {

--- a/internal/logic/public/order/resetTrafficLogic.go
+++ b/internal/logic/public/order/resetTrafficLogic.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/perfect-panel/server/internal/model/log"
 	"github.com/perfect-panel/server/pkg/constant"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/xerr"
 
 	"github.com/hibiken/asynq"
@@ -112,13 +113,13 @@ func (l *ResetTrafficLogic) ResetTraffic(req *types.ResetTrafficOrderRequest) (r
 				Amount:      orderInfo.GiftAmount,
 				Balance:     u.GiftAmount,
 				Remark:      "Renewal order deduction",
-				Timestamp:   time.Now().UnixMilli(),
+				Timestamp:   timeutil.Now().UnixMilli(),
 			}
 			content, _ := giftLog.Marshal()
 
 			if err = txStore.Log().Insert(l.ctx, &log.SystemLog{
 				Type:     log.TypeGift.Uint8(),
-				Date:     time.Now().Format(time.DateOnly),
+				Date:     timeutil.Now().Format(time.DateOnly),
 				ObjectID: u.Id,
 				Content:  string(content),
 			}); err != nil {

--- a/internal/logic/public/portal/purchaseCheckoutLogic.go
+++ b/internal/logic/public/portal/purchaseCheckoutLogic.go
@@ -12,6 +12,7 @@ import (
 	"github.com/perfect-panel/server/internal/repository"
 	"github.com/perfect-panel/server/pkg/constant"
 	"github.com/perfect-panel/server/pkg/exchangeRate"
+	"github.com/perfect-panel/server/pkg/timeutil"
 
 	paymentPlatform "github.com/perfect-panel/server/pkg/payment"
 
@@ -477,7 +478,7 @@ func (l *PurchaseCheckoutLogic) balancePayment(u *user.User, o *order.Order) err
 			err = store.Log().Insert(l.ctx, &log.SystemLog{
 				Type:     log.TypeGift.Uint8(),
 				ObjectID: userInfo.Id,
-				Date:     time.Now().Format(time.DateOnly),
+				Date:     timeutil.Now().Format(time.DateOnly),
 				Content:  string(content),
 			})
 			if err != nil {
@@ -492,13 +493,13 @@ func (l *PurchaseCheckoutLogic) balancePayment(u *user.User, o *order.Order) err
 				Type:      log.BalanceTypePayment, // Type 3 represents payment deduction
 				OrderNo:   o.OrderNo,
 				Balance:   userInfo.Balance,
-				Timestamp: time.Now().UnixMilli(),
+				Timestamp: timeutil.Now().UnixMilli(),
 			}
 			content, _ := balanceLog.Marshal()
 			err = store.Log().Insert(l.ctx, &log.SystemLog{
 				Type:     log.TypeBalance.Uint8(),
 				ObjectID: userInfo.Id,
-				Date:     time.Now().Format(time.DateOnly),
+				Date:     timeutil.Now().Format(time.DateOnly),
 				Content:  string(content),
 			})
 			if err != nil {

--- a/internal/logic/public/portal/purchaseLogic.go
+++ b/internal/logic/public/portal/purchaseLogic.go
@@ -13,6 +13,7 @@ import (
 	"github.com/perfect-panel/server/pkg/constant"
 	"github.com/perfect-panel/server/pkg/logger"
 	"github.com/perfect-panel/server/pkg/payment"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/tool"
 	"github.com/perfect-panel/server/pkg/xerr"
 	queue "github.com/perfect-panel/server/queue/types"
@@ -95,7 +96,7 @@ func (l *PurchaseLogic) Purchase(req *types.PortalPurchaseRequest) (resp *types.
 		}
 		// Check expiration time
 		expireTime := time.Unix(couponInfo.ExpireTime, 0)
-		if time.Now().After(expireTime) {
+		if timeutil.Now().After(expireTime) {
 			return nil, errors.Wrapf(xerr.NewErrCode(xerr.CouponExpired), "coupon expired")
 		}
 

--- a/internal/logic/public/portal/queryPurchaseOrderLogic.go
+++ b/internal/logic/public/portal/queryPurchaseOrderLogic.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/perfect-panel/server/internal/model/order"
 
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/tool"
 
 	"github.com/perfect-panel/server/internal/config"
@@ -126,7 +127,7 @@ func (l *QueryPurchaseOrderLogic) generateSessionToken(userId int64) (string, er
 	sessionId := uuidx.NewUUID().String()
 	token, err := jwt.NewJwtToken(
 		l.svcCtx.Config.JwtAuth.AccessSecret,
-		time.Now().Unix(),
+		timeutil.Now().Unix(),
 		l.svcCtx.Config.JwtAuth.AccessExpire,
 		jwt.WithOption("UserId", userId),
 		jwt.WithOption("SessionId", sessionId),

--- a/internal/logic/public/subscribe/queryUserSubscribeNodeListLogic.go
+++ b/internal/logic/public/subscribe/queryUserSubscribeNodeListLogic.go
@@ -3,7 +3,6 @@ package subscribe
 import (
 	"context"
 	"strings"
-	"time"
 
 	"github.com/perfect-panel/server/internal/model/node"
 	"github.com/perfect-panel/server/internal/model/user"
@@ -11,6 +10,7 @@ import (
 	"github.com/perfect-panel/server/internal/types"
 	"github.com/perfect-panel/server/pkg/constant"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/tool"
 	"github.com/perfect-panel/server/pkg/xerr"
 	"github.com/pkg/errors"
@@ -218,7 +218,7 @@ func (l *QueryUserSubscribeNodeListLogic) filterSubscribeNodes(nodeIds []int64, 
 }
 
 func (l *QueryUserSubscribeNodeListLogic) isSubscriptionExpired(userSub *user.Subscribe) bool {
-	return userSub.ExpireTime.Unix() < time.Now().Unix() && userSub.ExpireTime.Unix() != 0
+	return userSub.ExpireTime.Unix() < timeutil.Now().Unix() && userSub.ExpireTime.Unix() != 0
 }
 
 // isTrafficExhausted reports whether the subscription has used up its traffic

--- a/internal/logic/public/user/bindOAuthCallbackLogic.go
+++ b/internal/logic/public/user/bindOAuthCallbackLogic.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/perfect-panel/server/pkg/constant"
+	"github.com/perfect-panel/server/pkg/timeutil"
 
 	"github.com/perfect-panel/server/internal/model/auth"
 	"github.com/perfect-panel/server/internal/model/user"
@@ -262,10 +262,10 @@ func (l *BindOAuthCallbackLogic) telegram(req *types.BindOAuthCallbackRequest) e
 		return errors.Wrapf(xerr.NewErrCode(xerr.InvalidParams), "invalid telegram callback payload")
 	}
 
-	if time.Now().Unix()-*callbackData.AuthDate > telegramBindAuthExpire {
+	if timeutil.Now().Unix()-*callbackData.AuthDate > telegramBindAuthExpire {
 		l.Errorw("telegram auth date expired",
 			logger.Field("auth_date", *callbackData.AuthDate),
-			logger.Field("current_time", time.Now().Unix()),
+			logger.Field("current_time", timeutil.Now().Unix()),
 			logger.Field("expire_seconds", telegramBindAuthExpire),
 		)
 		return errors.Wrapf(xerr.NewErrCode(xerr.ERROR), "auth date expired")

--- a/internal/logic/public/user/bindTelegramLogic.go
+++ b/internal/logic/public/user/bindTelegramLogic.go
@@ -9,6 +9,7 @@ import (
 	"github.com/perfect-panel/server/internal/types"
 	"github.com/perfect-panel/server/pkg/constant"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/xerr"
 	"github.com/pkg/errors"
 )
@@ -40,6 +41,6 @@ func (l *BindTelegramLogic) BindTelegram() (resp *types.BindTelegramResponse, er
 	}
 	return &types.BindTelegramResponse{
 		Url:       fmt.Sprintf("https://t.me/%s?start=%s", l.svcCtx.Config.Telegram.BotName, session),
-		ExpiredAt: time.Now().Add(300 * time.Second).UnixMilli(),
+		ExpiredAt: timeutil.Now().Add(300 * time.Second).UnixMilli(),
 	}, nil
 }

--- a/internal/logic/public/user/commissionWithdrawLogic.go
+++ b/internal/logic/public/user/commissionWithdrawLogic.go
@@ -2,7 +2,6 @@ package user
 
 import (
 	"context"
-	"time"
 
 	"github.com/perfect-panel/server/internal/model/log"
 	"github.com/perfect-panel/server/internal/model/user"
@@ -11,6 +10,7 @@ import (
 	"github.com/perfect-panel/server/internal/types"
 	"github.com/perfect-panel/server/pkg/constant"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/xerr"
 	"github.com/pkg/errors"
 )
@@ -46,7 +46,7 @@ func (l *CommissionWithdrawLogic) CommissionWithdraw(req *types.CommissionWithdr
 	logInfo := log.Commission{
 		Type:      log.CommissionTypeConvertBalance,
 		Amount:    req.Amount,
-		Timestamp: time.Now().UnixMilli(),
+		Timestamp: timeutil.Now().UnixMilli(),
 	}
 	b, err := logInfo.Marshal()
 
@@ -65,10 +65,10 @@ func (l *CommissionWithdrawLogic) CommissionWithdraw(req *types.CommissionWithdr
 
 		if err = store.Log().Insert(l.ctx, &log.SystemLog{
 			Type:      log.TypeCommission.Uint8(),
-			Date:      time.Now().Format("2006-01-02"),
+			Date:      timeutil.Now().Format("2006-01-02"),
 			ObjectID:  u.Id,
 			Content:   string(b),
-			CreatedAt: time.Now(),
+			CreatedAt: timeutil.Now(),
 		}); err != nil {
 			l.Errorf("Failed to create commission log for user %d: %v", u.Id, err)
 			return errors.Wrapf(xerr.NewErrCode(xerr.DatabaseInsertError), "Failed to create commission log for user %d: %v", u.Id, err)
@@ -96,6 +96,6 @@ func (l *CommissionWithdrawLogic) CommissionWithdraw(req *types.CommissionWithdr
 		Content:   req.Content,
 		Status:    0,
 		Reason:    "",
-		CreatedAt: time.Now().UnixMilli(),
+		CreatedAt: timeutil.Now().UnixMilli(),
 	}, nil
 }

--- a/internal/logic/public/user/queryUserAffiliateLogic.go
+++ b/internal/logic/public/user/queryUserAffiliateLogic.go
@@ -36,25 +36,14 @@ func (l *QueryUserAffiliateLogic) QueryUserAffiliate() (resp *types.QueryUserAff
 		logger.Error("current user is not found in context")
 		return nil, errors.Wrapf(xerr.NewErrCode(xerr.InvalidAccess), "Invalid Access")
 	}
-	var sum int64
 	total, err := l.svcCtx.Store.User().CountAffiliates(l.ctx, u.Id)
 	if err != nil {
 		return nil, errors.Wrapf(xerr.NewErrCode(xerr.DatabaseQueryError), "Query User Affiliate failed: %v", err)
 	}
-	data, _, err := l.svcCtx.Store.Log().FilterSystemLog(l.ctx, &log.FilterParams{
-		Page:     1,
-		Size:     99999,
-		Type:     log.TypeCommission.Uint8(),
-		ObjectID: u.Id,
-	})
-
-	for _, datum := range data {
-		content := log.Commission{}
-		if err = content.Unmarshal([]byte(datum.Content)); err != nil {
-			l.Errorf("[QueryUserAffiliate] unmarshal comission log failed: %v", err.Error())
-			continue
-		}
-		sum += content.Amount
+	sum, err := l.svcCtx.Store.Log().SumAmountByTypeAndObjectID(l.ctx, log.TypeCommission.Uint8(), u.Id)
+	if err != nil {
+		l.Errorf("[QueryUserAffiliate] sum commission amount failed: %v", err.Error())
+		return nil, errors.Wrapf(xerr.NewErrCode(xerr.DatabaseQueryError), "Query User Affiliate sum commission failed: %v", err)
 	}
 
 	return &types.QueryUserAffiliateCountResponse{

--- a/internal/logic/public/user/queryUserBalanceLogLogic.go
+++ b/internal/logic/public/user/queryUserBalanceLogLogic.go
@@ -38,7 +38,7 @@ func (l *QueryUserBalanceLogLogic) QueryUserBalanceLog() (resp *types.QueryUserB
 
 	data, total, err := l.svcCtx.Store.Log().FilterSystemLog(l.ctx, &log.FilterParams{
 		Page:     1,
-		Size:     99999,
+		Size:     100,
 		Type:     log.TypeBalance.Uint8(),
 		ObjectID: u.Id,
 	})

--- a/internal/logic/public/user/queryUserSubscribeLogic.go
+++ b/internal/logic/public/user/queryUserSubscribeLogic.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/perfect-panel/server/pkg/constant"
+	"github.com/perfect-panel/server/pkg/timeutil"
 
 	"github.com/perfect-panel/server/internal/model/user"
 	"github.com/perfect-panel/server/internal/svc"
@@ -70,7 +71,7 @@ func (l *QueryUserSubscribeLogic) QueryUserSubscribe() (resp *types.QueryUserSub
 
 // 计算下次重置时间
 func calculateNextResetTime(sub *types.UserSubscribe) int64 {
-	now := time.Now()
+	now := timeutil.Now()
 	return calculateNextResetTimeAt(sub, now)
 }
 

--- a/internal/logic/public/user/resetUserSubscribeTokenLogic.go
+++ b/internal/logic/public/user/resetUserSubscribeTokenLogic.go
@@ -2,11 +2,11 @@ package user
 
 import (
 	"context"
-	"time"
 
 	"github.com/perfect-panel/server/internal/model/order"
 
 	"github.com/perfect-panel/server/pkg/constant"
+	"github.com/perfect-panel/server/pkg/timeutil"
 
 	"github.com/google/uuid"
 	"github.com/perfect-panel/server/internal/model/user"
@@ -63,7 +63,7 @@ func (l *ResetUserSubscribeTokenLogic) ResetUserSubscribeToken(req *types.ResetU
 		orderDetails = &order.Details{}
 	}
 
-	userSub.Token = uuidx.SubscribeToken(orderDetails.OrderNo + time.Now().Format("20060102150405.000"))
+	userSub.Token = uuidx.SubscribeToken(orderDetails.OrderNo + timeutil.Now().Format("20060102150405.000"))
 	userSub.UUID = uuid.New().String()
 	var newSub user.Subscribe
 	tool.DeepCopy(&newSub, userSub)

--- a/internal/logic/public/user/unbindTelegramLogic.go
+++ b/internal/logic/public/user/unbindTelegramLogic.go
@@ -3,9 +3,9 @@ package user
 import (
 	"context"
 	"strconv"
-	"time"
 
 	"github.com/perfect-panel/server/pkg/constant"
+	"github.com/perfect-panel/server/pkg/timeutil"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 	"github.com/perfect-panel/server/internal/logic/telegram"
@@ -65,7 +65,7 @@ func (l *UnbindTelegramLogic) UnbindTelegram() error {
 	// Unbind Telegram Success send message with chatId
 	text, err := tool.RenderTemplateToString(telegram.UnbindNotify, map[string]string{
 		"Id":   strconv.FormatInt(u.Id, 10),
-		"Time": time.Now().Format("2006-01-02 15:04:05"),
+		"Time": timeutil.Now().Format("2006-01-02 15:04:05"),
 	})
 	if err != nil {
 		l.Errorw("UnbindTelegramLogic RenderTemplateToString Error", logger.Field("id", u.Id), logger.Field("error", err.Error()))

--- a/internal/logic/public/user/unsubscribeLogic.go
+++ b/internal/logic/public/user/unsubscribeLogic.go
@@ -7,6 +7,7 @@ import (
 	"github.com/perfect-panel/server/internal/model/log"
 	"github.com/perfect-panel/server/internal/repository"
 	"github.com/perfect-panel/server/pkg/constant"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/tool"
 	"github.com/perfect-panel/server/pkg/xerr"
 	"github.com/pkg/errors"
@@ -103,13 +104,13 @@ func (l *UnsubscribeLogic) Unsubscribe(req *types.UnsubscribeRequest) error {
 				Amount:    balanceRefundAmount,
 				Type:      log.BalanceTypeRefund, // Type 4 represents refund transaction
 				Balance:   balance,
-				Timestamp: time.Now().UnixMilli(),
+				Timestamp: timeutil.Now().UnixMilli(),
 			}
 			content, _ := balanceLog.Marshal()
 
 			if err := store.Log().Insert(l.ctx, &log.SystemLog{
 				Type:     log.TypeBalance.Uint8(),
-				Date:     time.Now().Format(time.DateOnly),
+				Date:     timeutil.Now().Format(time.DateOnly),
 				ObjectID: u.Id,
 				Content:  string(content),
 			}); err != nil {
@@ -132,7 +133,7 @@ func (l *UnsubscribeLogic) Unsubscribe(req *types.UnsubscribeRequest) error {
 
 			if err := store.Log().Insert(l.ctx, &log.SystemLog{
 				Type:     log.TypeGift.Uint8(),
-				Date:     time.Now().Format(time.DateOnly),
+				Date:     timeutil.Now().Format(time.DateOnly),
 				ObjectID: u.Id,
 				Content:  string(content),
 			}); err != nil {

--- a/internal/logic/server/serverPushStatusLogic.go
+++ b/internal/logic/server/serverPushStatusLogic.go
@@ -3,12 +3,12 @@ package server
 import (
 	"context"
 	"errors"
-	"time"
 
 	"github.com/perfect-panel/server/internal/model/node"
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/internal/types"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 )
 
 type ServerPushStatusLogic struct {
@@ -43,7 +43,7 @@ func (l *ServerPushStatusLogic) ServerPushStatus(req *types.ServerPushStatusRequ
 		l.Errorw("[ServerPushStatus] UpdateNodeStatus error", logger.Field("error", err))
 		return errors.New("update node status failed")
 	}
-	now := time.Now()
+	now := timeutil.Now()
 	serverInfo.LastReportedAt = &now
 
 	err = l.svcCtx.Store.Node().UpdateServer(l.ctx, serverInfo)

--- a/internal/logic/server/serverPushUserTrafficLogic.go
+++ b/internal/logic/server/serverPushUserTrafficLogic.go
@@ -3,12 +3,12 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"time"
 
 	"github.com/hibiken/asynq"
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/internal/types"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/tool"
 	task "github.com/perfect-panel/server/queue/types"
 	"github.com/pkg/errors"
@@ -55,7 +55,7 @@ func (l *ServerPushUserTrafficLogic) ServerPushUserTraffic(req *types.ServerPush
 	}
 
 	// Update server last reported time
-	now := time.Now()
+	now := timeutil.Now()
 	serverInfo.LastReportedAt = &now
 
 	err = l.svcCtx.Store.Node().UpdateServer(l.ctx, serverInfo)

--- a/internal/logic/subscribe/subscribeLogic.go
+++ b/internal/logic/subscribe/subscribeLogic.go
@@ -18,6 +18,7 @@ import (
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/internal/types"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/tool"
 	"github.com/perfect-panel/server/pkg/xerr"
 	"github.com/pkg/errors"
@@ -228,7 +229,7 @@ func (l *SubscribeLogic) logSubscribeActivity(subscribeStatus bool, userSub *use
 	err := l.svc.Store.Log().Insert(l.ctx, &log.SystemLog{
 		Type:     log.TypeSubscribe.Uint8(),
 		ObjectID: userSub.UserId, // log user id
-		Date:     time.Now().Format(time.DateOnly),
+		Date:     timeutil.Now().Format(time.DateOnly),
 		Content:  string(content),
 	})
 	if err != nil {
@@ -281,7 +282,7 @@ func (l *SubscribeLogic) getServers(userSub *user.Subscribe) ([]*node.Node, erro
 }
 
 func (l *SubscribeLogic) isSubscriptionExpired(userSub *user.Subscribe) bool {
-	return userSub.ExpireTime.Unix() < time.Now().Unix() && userSub.ExpireTime.Unix() != 0
+	return userSub.ExpireTime.Unix() < timeutil.Now().Unix() && userSub.ExpireTime.Unix() != 0
 }
 
 // isTrafficExhausted reports whether the subscription has used up its traffic

--- a/internal/logic/telegram/telegramLogic.go
+++ b/internal/logic/telegram/telegramLogic.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"time"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 	"github.com/perfect-panel/server/internal/config"
 	"github.com/perfect-panel/server/internal/model/user"
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/tool"
 	"github.com/perfect-panel/server/pkg/xerr"
 	"github.com/pkg/errors"
@@ -101,8 +101,8 @@ func (l *TelegramLogic) start(req *tgbotapi.Update) error {
 				AuthType:       "telegram",
 				AuthIdentifier: strconv.FormatInt(req.Message.Chat.ID, 10),
 				Verified:       true,
-				CreatedAt:      time.Now(),
-				UpdatedAt:      time.Now(),
+				CreatedAt:      timeutil.Now(),
+				UpdatedAt:      timeutil.Now(),
 			}); err != nil {
 				l.Errorw("TelegramLogic start InsertUserAuthMethod Error: ", logger.Field("error", err.Error()), logger.Field("userId", userId))
 				return l.sendMessage(l.svcCtx.TelegramBot, "Bind failed!", req.Message.Chat.ID)
@@ -124,7 +124,7 @@ func (l *TelegramLogic) start(req *tgbotapi.Update) error {
 
 		text, err := tool.RenderTemplateToString(BindNotify, map[string]string{
 			"Id":   strconv.FormatInt(userId, 10),
-			"Time": time.Now().Format("2006-01-02 15:04:05"),
+			"Time": timeutil.Now().Format("2006-01-02 15:04:05"),
 		})
 		if err != nil {
 			return errors.Wrapf(xerr.NewErrCode(xerr.ERROR), "render template failed")

--- a/internal/model/log/log.go
+++ b/internal/model/log/log.go
@@ -60,19 +60,20 @@ func (t Type) Uint8() uint8 {
 
 // FilterParams log 列表查询过滤条件
 type FilterParams struct {
-	Page     int
-	Size     int
-	Type     uint8
-	Data     string
-	Search   string
-	ObjectID int64
+	Page      int
+	Size      int
+	Type      uint8
+	Data      string
+	Search    string
+	ObjectID  int64
+	SkipCount bool // when true, skip the COUNT(*) query (total will be 0)
 }
 
 // SystemLog represents a log entry in the system.
 type SystemLog struct {
 	Id        int64     `gorm:"primaryKey;AUTO_INCREMENT"`
 	Type      uint8     `gorm:"index:idx_type;type:tinyint(1);not null;default:0;comment:Log Type: 1: Email Message 2: Mobile Message 3: Subscribe 4: Subscribe Traffic 5: Server Traffic 6: Login 7: Register 8: Balance 9: Commission 10: Reset Subscribe 11: Gift"`
-	Date      string    `gorm:"type:varchar(20);default:null;comment:Log Date"`
+	Date      string    `gorm:"index:idx_date;type:varchar(20);default:null;comment:Log Date"`
 	ObjectID  int64     `gorm:"index:idx_object_id;type:bigint(20);not null;default:0;comment:Object ID"`
 	Content   string    `gorm:"type:text;not null;comment:Log Content"`
 	CreatedAt time.Time `gorm:"<-:create;comment:Create Time"`

--- a/internal/model/subscribe/subscribe.go
+++ b/internal/model/subscribe/subscribe.go
@@ -88,6 +88,8 @@ func (Group) TableName() string {
 	return "subscribe_group"
 }
 
+const MaxSubscribePageSize = 100
+
 // FilterParams subscribe 列表过滤参数
 type FilterParams struct {
 	Page            int      // Page Number
@@ -108,5 +110,8 @@ func (p *FilterParams) Normalize() {
 	}
 	if p.Size <= 0 {
 		p.Size = 10
+	}
+	if p.Size > MaxSubscribePageSize {
+		p.Size = MaxSubscribePageSize
 	}
 }

--- a/internal/repository/log.go
+++ b/internal/repository/log.go
@@ -3,11 +3,15 @@ package repository
 import (
 	"context"
 	"errors"
+	"fmt"
+	"time"
 
 	"github.com/perfect-panel/server/internal/model/log"
 	"github.com/perfect-panel/server/pkg/orm"
 	"gorm.io/gorm"
 )
+
+const maxLogPageSize = 100
 
 // LogRepo log 数据访问接口
 type LogRepo interface {
@@ -18,6 +22,8 @@ type LogRepo interface {
 	FilterSystemLog(ctx context.Context, filter *log.FilterParams) ([]*log.SystemLog, int64, error)
 	FindFirstByDateType(ctx context.Context, date string, typ uint8) (*log.SystemLog, error)
 	FindByDatesType(ctx context.Context, dates []string, typ uint8) ([]*log.SystemLog, error)
+	DeleteBefore(ctx context.Context, end time.Time) error
+	SumAmountByTypeAndObjectID(ctx context.Context, typ uint8, objectID int64) (int64, error)
 }
 
 var _ LogRepo = (*logRepo)(nil)
@@ -69,6 +75,9 @@ func (m *logRepo) FilterSystemLog(ctx context.Context, filter *log.FilterParams)
 	if filter.Size < 1 {
 		filter.Size = 10
 	}
+	if filter.Size > maxLogPageSize {
+		filter.Size = maxLogPageSize
+	}
 
 	if filter.Type != 0 {
 		tx = tx.Where("type = ?", filter.Type)
@@ -87,7 +96,12 @@ func (m *logRepo) FilterSystemLog(ctx context.Context, filter *log.FilterParams)
 
 	var total int64
 	var logs []*log.SystemLog
-	err := tx.Count(&total).Limit(filter.Size).Offset((filter.Page - 1) * filter.Size).Find(&logs).Error
+	if !filter.SkipCount {
+		if err := tx.Count(&total).Error; err != nil {
+			return nil, 0, err
+		}
+	}
+	err := tx.Limit(filter.Size).Offset((filter.Page - 1) * filter.Size).Find(&logs).Error
 	return logs, total, err
 }
 
@@ -112,4 +126,31 @@ func (m *logRepo) FindByDatesType(ctx context.Context, dates []string, typ uint8
 	}
 	err := m.WithContext(ctx).Model(&log.SystemLog{}).Where("date IN ? AND type = ?", dates, typ).Find(&data).Error
 	return data, err
+}
+
+// DeleteBefore deletes system logs whose date is before the given end date.
+func (m *logRepo) DeleteBefore(ctx context.Context, end time.Time) error {
+	return m.WithContext(ctx).
+		Where("date < ?", end.Format(time.DateOnly)).
+		Delete(&log.SystemLog{}).Error
+}
+
+// SumAmountByTypeAndObjectID returns the sum of the "amount" field extracted from JSON content
+// for all system logs matching the given type and object ID.
+func (m *logRepo) SumAmountByTypeAndObjectID(ctx context.Context, typ uint8, objectID int64) (int64, error) {
+	jsonExtract := jsonAmountExpr(m.DB)
+	var sum int64
+	err := m.WithContext(ctx).
+		Model(&log.SystemLog{}).
+		Select(fmt.Sprintf("COALESCE(SUM(%s), 0)", jsonExtract)).
+		Where("type = ? AND object_id = ?", typ, objectID).
+		Scan(&sum).Error
+	return sum, err
+}
+
+func jsonAmountExpr(db *gorm.DB) string {
+	if db != nil && db.Dialector.Name() == orm.DriverPostgres {
+		return "(content::json->>'amount')::bigint"
+	}
+	return "CAST(JSON_EXTRACT(content, '$.amount') AS SIGNED)"
 }

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -12,6 +12,7 @@ import (
 	"github.com/perfect-panel/server/pkg/cache"
 	"github.com/perfect-panel/server/pkg/logger"
 	"github.com/perfect-panel/server/pkg/orm"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/redis/go-redis/v9"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -898,9 +899,9 @@ func (m *userRepo) QueryUserSubscribe(ctx context.Context, userId int64, status 
 	key := fmt.Sprintf("%s%d", cacheUserSubscribeUserPrefix, userId)
 	err := m.QueryCtx(ctx, &list, key, func(conn *gorm.DB, v interface{}) error {
 		// 获取当前时间
-		now := time.Now()
+		now := timeutil.Now()
 		// 获取当前时间向前推 7 天
-		sevenDaysAgo := time.Now().Add(-7 * 24 * time.Hour)
+		sevenDaysAgo := timeutil.Now().Add(-7 * 24 * time.Hour)
 		// 基础条件查询
 		conn = conn.Model(&user.Subscribe{}).Where("user_id = ?", userId)
 		if len(status) > 0 {

--- a/internal/svc/devce.go
+++ b/internal/svc/devce.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/perfect-panel/server/pkg/device"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 )
@@ -37,7 +38,7 @@ func NewDeviceManager(srv *ServiceContext) *device.DeviceManager {
 		}
 
 		//当前时间为设备离线时间
-		currentTime := time.Now()
+		currentTime := timeutil.Now()
 		endTime := currentTime.Format("2006-01-02 00:00:00")
 		parseStart, _ := time.Parse(time.DateTime, endTime)
 		startTime := parseStart.Add(time.Hour * 24).Format(time.DateTime)

--- a/pkg/timeutil/timeutil.go
+++ b/pkg/timeutil/timeutil.go
@@ -1,0 +1,89 @@
+// Package timeutil provides centralized timezone handling for the application.
+// Call LoadLocation once during initialization to set the canonical timezone,
+// then use Now() and Location() throughout business logic instead of time.Now()
+// and time.Local.
+package timeutil
+
+import (
+	"sync"
+	"time"
+)
+
+var (
+	mu   sync.RWMutex
+	loc  *time.Location
+	name string
+)
+
+// LoadLocation loads the timezone by name (e.g., "Asia/Shanghai", "UTC").
+// Must be called once at startup before any other function in this package.
+func LoadLocation(tzName string) error {
+	mu.Lock()
+	defer mu.Unlock()
+
+	l, err := time.LoadLocation(tzName)
+	if err != nil {
+		return err
+	}
+	loc = l
+	name = tzName
+	return nil
+}
+
+// Location returns the canonical application timezone.
+// Falls back to time.Local if LoadLocation was never called.
+func Location() *time.Location {
+	mu.RLock()
+	defer mu.RUnlock()
+	if loc == nil {
+		return time.Local
+	}
+	return loc
+}
+
+// LocationName returns the configured timezone name.
+func LocationName() string {
+	mu.RLock()
+	defer mu.RUnlock()
+	if name == "" {
+		return "Local"
+	}
+	return name
+}
+
+// Now returns the current time in the application timezone.
+// Falls back to time.Now() if LoadLocation was never called.
+func Now() time.Time {
+	return time.Now().In(Location())
+}
+
+// TodayStart returns the start of today (00:00:00) in the application timezone.
+func TodayStart() time.Time {
+	now := Now()
+	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, Location())
+}
+
+// TodayEnd returns the end of today (24:00:00) in the application timezone.
+func TodayEnd() time.Time {
+	return TodayStart().Add(24 * time.Hour)
+}
+
+// FormatDate formats a time as "2006-01-02" in the application timezone.
+func FormatDate(t time.Time) string {
+	return t.In(Location()).Format("2006-01-02")
+}
+
+// ParseDate parses a "2006-01-02" string in the application timezone.
+func ParseDate(s string) (time.Time, error) {
+	return time.ParseInLocation("2006-01-02", s, Location())
+}
+
+// UnixMilli returns the UnixMilli of the given time (for timestamp fields).
+func UnixMilli(t time.Time) int64 {
+	return t.UnixMilli()
+}
+
+// InLoc converts a time to the application timezone.
+func InLoc(t time.Time) time.Time {
+	return t.In(Location())
+}

--- a/queue/logic/email/sendEmailLogic.go
+++ b/queue/logic/email/sendEmailLogic.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"text/template"
-	"time"
 
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 
 	"github.com/hibiken/asynq"
 	"github.com/perfect-panel/server/internal/model/log"
@@ -141,7 +141,7 @@ func (l *SendEmailLogic) ProcessTask(ctx context.Context, task *asynq.Task) erro
 
 	if err = l.svcCtx.Store.Log().Insert(ctx, &log.SystemLog{
 		Type:     log.TypeEmailMessage.Uint8(),
-		Date:     time.Now().Format("2006-01-02"),
+		Date:     timeutil.Now().Format("2006-01-02"),
 		ObjectID: 0,
 		Content:  string(emailLog),
 	}); err != nil {

--- a/queue/logic/order/activateOrderLogic.go
+++ b/queue/logic/order/activateOrderLogic.go
@@ -12,6 +12,7 @@ import (
 	"github.com/perfect-panel/server/internal/model/log"
 	"github.com/perfect-panel/server/pkg/constant"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 	"github.com/google/uuid"
@@ -339,7 +340,7 @@ func (l *ActivateOrderLogic) getSubscribeInfo(ctx context.Context, subscribeId i
 
 // createUserSubscription creates a new user subscription record based on order and subscription plan details
 func (l *ActivateOrderLogic) createUserSubscription(ctx context.Context, orderInfo *order.Order, sub *subscribe.Subscribe) (*user.Subscribe, error) {
-	now := time.Now()
+	now := timeutil.Now()
 	userSub := &user.Subscribe{
 		UserId:      orderInfo.UserId,
 		OrderId:     orderInfo.Id,
@@ -430,7 +431,7 @@ func (l *ActivateOrderLogic) handleCommission(ctx context.Context, userInfo *use
 		content, _ := commissionLog.Marshal()
 		return store.Log().Insert(ctx, &log.SystemLog{
 			Type:     log.TypeCommission.Uint8(),
-			Date:     time.Now().Format("2006-01-02"),
+			Date:     timeutil.Now().Format("2006-01-02"),
 			ObjectID: referer.Id,
 			Content:  string(content),
 		})
@@ -556,11 +557,11 @@ func (l *ActivateOrderLogic) getUserSubscription(ctx context.Context, token stri
 // updateSubscriptionForRenewal updates subscription details for renewal including
 // expiration time extension and traffic reset if configured
 func (l *ActivateOrderLogic) updateSubscriptionForRenewal(ctx context.Context, userSub *user.Subscribe, sub *subscribe.Subscribe, orderInfo *order.Order) error {
-	now := time.Now()
+	now := timeutil.Now()
 	if userSub.ExpireTime.Before(now) {
 		userSub.ExpireTime = now
 	}
-	today := time.Now().Day()
+	today := timeutil.Now().Day()
 	resetDay := userSub.ExpireTime.Day()
 
 	// Reset traffic if enabled
@@ -635,13 +636,13 @@ func (l *ActivateOrderLogic) ResetTraffic(ctx context.Context, orderInfo *order.
 		Type:      log.ResetSubscribeTypePaid,
 		UserId:    userInfo.Id,
 		OrderNo:   orderInfo.OrderNo,
-		Timestamp: time.Now().UnixMilli(),
+		Timestamp: timeutil.Now().UnixMilli(),
 	}
 
 	content, _ := resetLog.Marshal()
 	if err = l.svc.Store.Log().Insert(ctx, &log.SystemLog{
 		Type:     log.TypeResetSubscribe.Uint8(),
-		Date:     time.Now().Format(time.DateOnly),
+		Date:     timeutil.Now().Format(time.DateOnly),
 		ObjectID: userSub.Id,
 		Content:  string(content),
 	}); err != nil {
@@ -674,13 +675,13 @@ func (l *ActivateOrderLogic) Recharge(ctx context.Context, orderInfo *order.Orde
 			Type:      log.BalanceTypeRecharge,
 			OrderNo:   orderInfo.OrderNo,
 			Balance:   userInfo.Balance,
-			Timestamp: time.Now().UnixMilli(),
+			Timestamp: timeutil.Now().UnixMilli(),
 		}
 		content, _ := balanceLog.Marshal()
 
 		return store.Log().Insert(ctx, &log.SystemLog{
 			Type:     log.TypeBalance.Uint8(),
-			Date:     time.Now().Format("2006-01-02"),
+			Date:     timeutil.Now().Format("2006-01-02"),
 			ObjectID: userInfo.Id,
 			Content:  string(content),
 		})
@@ -760,7 +761,7 @@ func (l *ActivateOrderLogic) buildUserNotificationData(orderInfo *order.Order, s
 
 	if userSub != nil {
 		data["ExpireTime"] = userSub.ExpireTime.Format("2006-01-02 15:04:05")
-		data["ResetTime"] = time.Now().Format("2006-01-02 15:04:05")
+		data["ResetTime"] = timeutil.Now().Format("2006-01-02 15:04:05")
 	}
 
 	return data

--- a/queue/logic/sms/sendSmsLogic.go
+++ b/queue/logic/sms/sendSmsLogic.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 
 	"github.com/hibiken/asynq"
 	"github.com/perfect-panel/server/internal/model/log"
@@ -68,7 +68,7 @@ func (l *SendSmsLogic) ProcessTask(ctx context.Context, task *asynq.Task) error 
 	content, _ := createSms.Marshal()
 	err = l.svcCtx.Store.Log().Insert(ctx, &log.SystemLog{
 		Type:     log.TypeMobileMessage.Uint8(),
-		Date:     time.Now().Format("2006-01-02"),
+		Date:     timeutil.Now().Format("2006-01-02"),
 		ObjectID: 0,
 		Content:  string(content),
 	})

--- a/queue/logic/subscription/checkSubscriptionLogic.go
+++ b/queue/logic/subscription/checkSubscriptionLogic.go
@@ -3,11 +3,11 @@ package subscription
 import (
 	"context"
 	"encoding/json"
-	"time"
 
 	queue "github.com/perfect-panel/server/queue/types"
 
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 
 	"github.com/hibiken/asynq"
 	"github.com/perfect-panel/server/internal/model/user"
@@ -26,7 +26,7 @@ func NewCheckSubscriptionLogic(svc *svc.ServiceContext) *CheckSubscriptionLogic 
 }
 
 func (l *CheckSubscriptionLogic) ProcessTask(ctx context.Context, _ *asynq.Task) error {
-	logger.Infof("[CheckSubscription] Start check subscription: %s", time.Now().Format("2006-01-02 15:04:05"))
+	logger.Infof("[CheckSubscription] Start check subscription: %s", timeutil.Now().Format("2006-01-02 15:04:05"))
 	// Check subscription traffic
 	err := l.svc.Store.InTx(ctx, func(store repository.Store) error {
 		list, err := store.User().FindTrafficExceededSubscribes(ctx)
@@ -39,7 +39,7 @@ func (l *CheckSubscriptionLogic) ProcessTask(ctx context.Context, _ *asynq.Task)
 			ids = append(ids, item.Id)
 		}
 		if len(ids) > 0 {
-			if err = store.User().MarkSubscribesFinished(ctx, ids, 2, time.Now()); err != nil {
+			if err = store.User().MarkSubscribesFinished(ctx, ids, 2, timeutil.Now()); err != nil {
 				logger.Errorw("[Check Subscription Traffic] Update subscribe status failed", logger.Field("error", err.Error()))
 				return nil
 			}
@@ -69,7 +69,7 @@ func (l *CheckSubscriptionLogic) ProcessTask(ctx context.Context, _ *asynq.Task)
 	}
 	// Check subscription expire
 	err = l.svc.Store.InTx(ctx, func(store repository.Store) error {
-		list, err := store.User().FindExpiredSubscribes(ctx, time.Now())
+		list, err := store.User().FindExpiredSubscribes(ctx, timeutil.Now())
 		if err != nil {
 			logger.Error("[Check Subscription] Find subscribe failed", logger.Field("error", err.Error()))
 			return err
@@ -79,7 +79,7 @@ func (l *CheckSubscriptionLogic) ProcessTask(ctx context.Context, _ *asynq.Task)
 			ids = append(ids, item.Id)
 		}
 		if len(ids) > 0 {
-			if err = store.User().MarkSubscribesFinished(ctx, ids, 3, time.Now()); err != nil {
+			if err = store.User().MarkSubscribesFinished(ctx, ids, 3, timeutil.Now()); err != nil {
 				logger.Error("[Check Subscription Expire] Update subscribe status failed", logger.Field("error", err.Error()))
 				return err
 			}

--- a/queue/logic/task/quotaLogic.go
+++ b/queue/logic/task/quotaLogic.go
@@ -14,6 +14,7 @@ import (
 	"github.com/perfect-panel/server/internal/repository"
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/tool"
 )
 
@@ -167,7 +168,7 @@ func (l *QuotaTaskLogic) getSubscribes(ctx context.Context, subscriberIDs []int6
 func (l *QuotaTaskLogic) processSubscribes(ctx context.Context, subscribes []*user.Subscribe, content task.QuotaContent, taskInfo *task.Task) error {
 	return l.svcCtx.Store.InTx(ctx, func(store repository.Store) error {
 		var errors []ErrorInfo
-		now := time.Now()
+		now := timeutil.Now()
 
 		for _, sub := range subscribes {
 			if err := l.processSubscription(ctx, store, sub, content, now, &errors); err != nil {

--- a/queue/logic/traffic/resetTrafficLogic.go
+++ b/queue/logic/traffic/resetTrafficLogic.go
@@ -13,6 +13,7 @@ import (
 	"github.com/perfect-panel/server/internal/repository"
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/queue/types"
 
 	"github.com/hibiken/asynq"
@@ -56,7 +57,7 @@ func NewResetTrafficLogic(svc *svc.ServiceContext) *ResetTrafficLogic {
 // ProcessTask executes the traffic reset task for all subscription types with enhanced retry mechanism
 func (l *ResetTrafficLogic) ProcessTask(ctx context.Context, _ *asynq.Task) error {
 	var err error
-	startTime := time.Now()
+	startTime := timeutil.Now()
 
 	// Get current retry count
 	retryCount := l.getRetryCount(ctx)
@@ -178,7 +179,7 @@ func (l *ResetTrafficLogic) ProcessTask(ctx context.Context, _ *asynq.Task) erro
 // resetMonth handles monthly cycle reset based on subscription start date
 // reset_cycle = 2: Reset monthly based on subscription start date
 func (l *ResetTrafficLogic) resetMonth(ctx context.Context) error {
-	now := time.Now()
+	now := timeutil.Now()
 
 	err := l.svc.Store.InTx(ctx, func(store repository.Store) error {
 		// Get all subscriptions that reset monthly based on start date
@@ -235,7 +236,7 @@ func (l *ResetTrafficLogic) resetMonth(ctx context.Context) error {
 // reset1st handles reset on 1st of every month
 // reset_cycle = 1: Reset on 1st of every month
 func (l *ResetTrafficLogic) reset1st(ctx context.Context, cache resetTrafficCache) error {
-	now := time.Now()
+	now := timeutil.Now()
 
 	// Check if we already reset this month using cache
 	if firstDayResetAlreadyProcessed(now, cache) {
@@ -314,7 +315,7 @@ func firstDayResetAlreadyProcessed(now time.Time, cache resetTrafficCache) bool 
 // resetYear handles yearly reset based on subscription start date anniversary
 // reset_cycle = 3: Reset yearly based on subscription start date
 func (l *ResetTrafficLogic) resetYear(ctx context.Context) error {
-	now := time.Now()
+	now := timeutil.Now()
 
 	err := l.svc.Store.InTx(ctx, func(store repository.Store) error {
 		// Get all subscriptions that reset yearly
@@ -553,7 +554,7 @@ func (l *ResetTrafficLogic) insertLog(subId, userId int64) {
 	trafficLog := log.ResetSubscribe{
 		Type:      log.ResetSubscribeTypeAuto,
 		UserId:    userId,
-		Timestamp: time.Now().UnixMilli(),
+		Timestamp: timeutil.Now().UnixMilli(),
 	}
 	content, _ := trafficLog.Marshal()
 	logCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -561,7 +562,7 @@ func (l *ResetTrafficLogic) insertLog(subId, userId int64) {
 	if err := l.svc.Store.Log().Insert(logCtx, &log.SystemLog{
 		Type:     log.TypeResetSubscribe.Uint8(),
 		ObjectID: subId,
-		Date:     time.Now().Format(time.DateOnly),
+		Date:     timeutil.Now().Format(time.DateOnly),
 		Content:  string(content),
 	}); err != nil {
 		logger.Errorw("[ResetTraffic] Failed to create system log for subscription", logger.Field("error", err.Error()))

--- a/queue/logic/traffic/serverDataLogic.go
+++ b/queue/logic/traffic/serverDataLogic.go
@@ -3,9 +3,9 @@ package traffic
 import (
 	"context"
 	"encoding/json"
-	"time"
 
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 
 	"github.com/hibiken/asynq"
 	"github.com/perfect-panel/server/internal/config"
@@ -48,7 +48,7 @@ func (l *ServerDataLogic) ProcessTask(ctx context.Context, _ *asynq.Task) error 
 	serverData.TodayDownload = totalDownloadToday
 	serverData.MonthlyUpload = totalUploadMonthly
 	serverData.MonthlyDownload = totalDownloadMonthly
-	serverData.UpdatedAt = time.Now().UnixMilli()
+	serverData.UpdatedAt = timeutil.Now().UnixMilli()
 	data, err := json.Marshal(serverData)
 	if err != nil {
 		logger.Error("[ServerDataLogic] Marshal server data failed", logger.Field("error", err.Error()), logger.Field("data", serverData))
@@ -63,7 +63,7 @@ func (l *ServerDataLogic) ProcessTask(ctx context.Context, _ *asynq.Task) error 
 }
 
 func (l *ServerDataLogic) getRanking(ctx context.Context) (top10ServerToday, top10ServerYesterday []types.ServerTrafficData, top10UserToday, top10UserYesterday []types.UserTrafficData) {
-	now := time.Now()
+	now := timeutil.Now()
 	// 获取服务器流量排行榜
 	serverToday, err := l.svc.Store.TrafficLog().TopServersTrafficByDay(ctx, now, 10)
 	if err != nil {
@@ -146,7 +146,7 @@ func (l *ServerDataLogic) getRanking(ctx context.Context) (top10ServerToday, top
 }
 
 func (l *ServerDataLogic) trafficCount(ctx context.Context) (totalUploadToday, totalDownloadToday, totalDownloadMonthly, totalUploadMonthly int64) {
-	now := time.Now()
+	now := timeutil.Now()
 	today, err := l.svc.Store.TrafficLog().QueryTrafficByDay(ctx, now)
 	if err != nil {
 		logger.Error("[ServerDataLogic] Query traffic by day failed", logger.Field("error", err.Error()))

--- a/queue/logic/traffic/trafficStatLogic.go
+++ b/queue/logic/traffic/trafficStatLogic.go
@@ -9,6 +9,7 @@ import (
 	"github.com/perfect-panel/server/internal/repository"
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 )
 
 type StatLogic struct {
@@ -22,11 +23,11 @@ func NewStatLogic(svc *svc.ServiceContext) *StatLogic {
 }
 
 func (l *StatLogic) ProcessTask(ctx context.Context, _ *asynq.Task) error {
-	now := time.Now()
+	now := timeutil.Now()
 
 	// 获取全部有效订阅
 	// 获取统计时间范围
-	start := time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, time.Local)
+	start := time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, timeutil.Location())
 	end := start.Add(24 * time.Hour)
 
 	err := l.svc.Store.InTx(ctx, func(store repository.Store) error {
@@ -156,9 +157,14 @@ func (l *StatLogic) ProcessTask(ctx context.Context, _ *asynq.Task) error {
 
 		// Delete old traffic logs
 		if l.svc.Config.Log.AutoClear {
-			err = store.TrafficLog().DeleteBefore(ctx, end.AddDate(0, 0, int(-l.svc.Config.Log.ClearDays)))
+			threshold := end.AddDate(0, 0, int(-l.svc.Config.Log.ClearDays))
+			err = store.TrafficLog().DeleteBefore(ctx, threshold)
 			if err != nil {
 				logger.Errorf("[Traffic Stat Queue] Delete server traffic log failed: %v", err.Error())
+			}
+			// Delete old system logs
+			if err = store.Log().DeleteBefore(ctx, threshold); err != nil {
+				logger.Errorf("[Traffic Stat Queue] Delete old system logs failed: %v", err.Error())
 			}
 		}
 		return nil

--- a/queue/logic/traffic/trafficStatisticsLogic.go
+++ b/queue/logic/traffic/trafficStatisticsLogic.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
-	"time"
 
 	"github.com/perfect-panel/server/internal/model/node"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 
 	"github.com/hibiken/asynq"
 	"github.com/perfect-panel/server/internal/model/traffic"
@@ -77,7 +77,7 @@ func (l *TrafficStatisticsLogic) ProcessTask(ctx context.Context, task *asynq.Ta
 		ratio = float32(protocol.Ratio)
 	}
 
-	now := time.Now()
+	now := timeutil.Now()
 	realTimeMultiplier := l.svc.NodeMultiplierManager.GetMultiplier(now)
 	logger.Debugf("[TrafficStatisticsLogic] Current time traffic multiplier: %.2f", realTimeMultiplier)
 	for _, log := range payload.Logs {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -63,7 +63,11 @@ func (m *Service) Stop() {
 }
 
 func initService(svc *svc.ServiceContext) *asynq.Scheduler {
-	location, _ := time.LoadLocation("Asia/Shanghai")
+	location, err := time.LoadLocation(svc.Config.AppLocation)
+	if err != nil {
+		logger.Errorf("load timezone location %q failed: %v, falling back to Local", svc.Config.AppLocation, err)
+		location = time.Local
+	}
 	return asynq.NewScheduler(
 		asynq.RedisClientOpt{Addr: svc.Config.Redis.Host, Password: svc.Config.Redis.Pass, DB: 5},
 		&asynq.SchedulerOpts{


### PR DESCRIPTION
## Log System Optimization (P0-P2)

### P0: Critical fixes
- Add idx_date index on system_logs.date to prevent full table scans
- Add MaxSize=100 limit in FilterSystemLog to prevent frontend freeze from large responses
- Fix GetUserSubscribeLogsLogic ignoring all request parameters (empty FilterParams bug)
- Add migration files (02132) for date index (MySQL + PostgreSQL)

### P1: Stability fixes
- Add DeleteBefore to LogRepo for system_logs cleanup (was only cleaning traffic_log)
- Add SumAmountByTypeAndObjectID to LogRepo for DB-level commission aggregation
- Fix queryUserAffiliateLogic from fetching all records in Go to single DB SUM query
- Fix queryUserBalanceLogLogic hardcoded Size:99999 to 100

### P2: Further improvements
- Add FULLTEXT index on system_logs.content (MySQL) and GIN index (PostgreSQL) - migration 02133
- Add MaxSubscribePageSize=100 limit in Subscribe FilterList Normalize()
- Add SkipCount option to FilterParams for queries that don't need total count

## Timezone Unification

### Root cause
Three-way timezone mismatch between:
1. Scheduler (hardcoded Asia/Shanghai)
2. Business logic (OS-dependent time.Now()/time.Local)
3. Database timestamp columns without timezone

### Fix
- Add AppLocation config field (default: Asia/Shanghai)
- Create pkg/timeutil with Now()/Location() for centralized timezone
- Replace time.Now() → timeutil.Now() and time.Local → timeutil.Location() across 50+ files in internal/logic, queue/logic, repository, svc
- Scheduler reads location from config instead of hardcoded value