### PR TITLE
fix: save external trade_no during payment callback

### DIFF
--- a/internal/logic/notify/alipayNotifyLogic.go
+++ b/internal/logic/notify/alipayNotifyLogic.go
@@ -73,8 +73,8 @@ func (l *AlipayNotifyLogic) AlipayNotify(r *http.Request) error {
 			return nil
 		}
 
-		// Update order status
-		err = store.Order().UpdateOrderStatus(l.ctx, notify.OrderNo, 2)
+		// Update order status and trade_no
+		err = store.Order().UpdateOrderStatusAndTradeNo(l.ctx, notify.OrderNo, 2, notify.TradeNo)
 		if err != nil {
 			l.Logger.Error("[AlipayNotify] Update order status failed", logger.Field("error", err.Error()), logger.Field("orderNo", notify.OrderNo))
 			return err

--- a/internal/logic/notify/ePayNotifyLogic.go
+++ b/internal/logic/notify/ePayNotifyLogic.go
@@ -87,8 +87,8 @@ func (l *EPayNotifyLogic) EPayNotify(req *types.EPayNotifyRequest) error {
 	if orderInfo.Status == 5 {
 		return nil
 	}
-	// Update order status
-	err = store.Order().UpdateOrderStatus(l.ctx, req.OutTradeNo, 2)
+	// Update order status and trade_no
+	err = store.Order().UpdateOrderStatusAndTradeNo(l.ctx, req.OutTradeNo, 2, req.TradeNo)
 	if err != nil {
 		l.Logger.Error("[EPayNotify] Update order status failed", logger.Field("error", err.Error()), logger.Field("orderNo", req.OutTradeNo))
 		return err

--- a/internal/logic/notify/stripeNotifyLogic.go
+++ b/internal/logic/notify/stripeNotifyLogic.go
@@ -72,8 +72,8 @@ func (l *StripeNotifyLogic) StripeNotify(r *http.Request, w http.ResponseWriter)
 		if orderInfo.Status == 5 {
 			return nil
 		}
-		// update order status
-		err = store.Order().UpdateOrderStatus(l.ctx, notify.OrderNo, 2)
+		// update order status and trade_no
+		err = store.Order().UpdateOrderStatusAndTradeNo(l.ctx, notify.OrderNo, 2, notify.TradeNo)
 		if err != nil {
 			return err
 		}

--- a/internal/repository/order.go
+++ b/internal/repository/order.go
@@ -218,7 +218,7 @@ func (m *orderRepo) UpdateOrderStatus(ctx context.Context, orderNo string, statu
 }
 
 // UpdateOrderStatusAndTradeNo Update order status and trade number
-func (m *customOrderModel) UpdateOrderStatusAndTradeNo(ctx context.Context, orderNo string, status uint8, tradeNo string, tx ...*gorm.DB) error {
+func (m *orderRepo) UpdateOrderStatusAndTradeNo(ctx context.Context, orderNo string, status uint8, tradeNo string, tx ...*gorm.DB) error {
 	orderInfo, err := m.FindOneByOrderNo(ctx, orderNo)
 	if err != nil {
 		return err
@@ -227,7 +227,7 @@ func (m *customOrderModel) UpdateOrderStatusAndTradeNo(ctx context.Context, orde
 		if len(tx) > 0 {
 			conn = tx[0]
 		}
-		return conn.Model(&Order{}).Where("order_no = ?", orderNo).Updates(map[string]interface{}{
+		return conn.Model(&order.Order{}).Where("order_no = ?", orderNo).Updates(map[string]interface{}{
 			"status":   status,
 			"trade_no": tradeNo,
 		}).Error

--- a/internal/repository/order.go
+++ b/internal/repository/order.go
@@ -30,6 +30,7 @@ type OrderRepo interface {
 	Delete(ctx context.Context, id int64, tx ...*gorm.DB) error
 	Transaction(ctx context.Context, fn func(db *gorm.DB) error) error
 	UpdateOrderStatus(ctx context.Context, orderNo string, status uint8, tx ...*gorm.DB) error
+	UpdateOrderStatusAndTradeNo(ctx context.Context, orderNo string, status uint8, tradeNo string, tx ...*gorm.DB) error
 	CountUserCouponUsage(ctx context.Context, userID int64, coupon string) (int64, error)
 	QueryOrderListByPage(ctx context.Context, page, size int, status uint8, user, subscribe int64, search string) (int64, []*order.Details, error)
 	FindOneDetails(ctx context.Context, id int64) (*order.Details, error)
@@ -213,6 +214,23 @@ func (m *orderRepo) UpdateOrderStatus(ctx context.Context, orderNo string, statu
 			conn = tx[0]
 		}
 		return conn.Model(&order.Order{}).Where("order_no = ?", orderNo).Update("status", status).Error
+	}, m.getCacheKeys(orderInfo)...)
+}
+
+// UpdateOrderStatusAndTradeNo Update order status and trade number
+func (m *customOrderModel) UpdateOrderStatusAndTradeNo(ctx context.Context, orderNo string, status uint8, tradeNo string, tx ...*gorm.DB) error {
+	orderInfo, err := m.FindOneByOrderNo(ctx, orderNo)
+	if err != nil {
+		return err
+	}
+	return m.ExecCtx(ctx, func(conn *gorm.DB) error {
+		if len(tx) > 0 {
+			conn = tx[0]
+		}
+		return conn.Model(&Order{}).Where("order_no = ?", orderNo).Updates(map[string]interface{}{
+			"status":   status,
+			"trade_no": tradeNo,
+		}).Error
 	}, m.getCacheKeys(orderInfo)...)
 }
 

--- a/internal/repository/order_test.go
+++ b/internal/repository/order_test.go
@@ -1,14 +1,55 @@
 package repository
 
 import (
+	"bytes"
+	"context"
+	"log"
 	"strings"
 	"testing"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/perfect-panel/server/internal/model/order"
+	"github.com/redis/go-redis/v9"
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
 )
+
+func TestOrderRepoUpdateOrderStatusAndTradeNoUpdatesBothFields(t *testing.T) {
+	var logs bytes.Buffer
+	db, err := gorm.Open(mysql.New(mysql.Config{
+		DSN:                       "gorm:gorm@tcp(localhost:9910)/gorm?charset=utf8&parseTime=True&loc=Local",
+		SkipInitializeWithVersion: true,
+	}), &gorm.Config{
+		DryRun:                 true,
+		DisableAutomaticPing:   true,
+		SkipDefaultTransaction: true,
+		Logger: gormlogger.New(log.New(&logs, "", 0), gormlogger.Config{
+			LogLevel: gormlogger.Info,
+		}),
+	})
+	if err != nil {
+		t.Fatalf("open gorm db: %v", err)
+	}
+
+	redisServer := miniredis.RunT(t)
+	redisClient := redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	t.Cleanup(func() { _ = redisClient.Close() })
+	repo := newOrderRepo(db, redisClient)
+
+	err = repo.UpdateOrderStatusAndTradeNo(context.Background(), "order-123", 2, "trade-456")
+	if err != nil {
+		t.Fatalf("update order status and trade number: %v", err)
+	}
+
+	sql := logs.String()
+	for _, want := range []string{"UPDATE `order`", "`status`=2", "`trade_no`='trade-456'", "WHERE order_no = 'order-123'"} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("SQL missing %q:\n%s", want, sql)
+		}
+	}
+}
 
 func TestApplyOrderListFiltersSearchSQL(t *testing.T) {
 	tests := []struct {

--- a/pkg/payment/alipay/alipay.go
+++ b/pkg/payment/alipay/alipay.go
@@ -23,6 +23,7 @@ type Notification struct {
 	OrderNo string
 	Amount  int64
 	Status  Status
+	TradeNo string
 }
 
 type Status string
@@ -110,5 +111,6 @@ func (c *Client) DecodeNotification(form url.Values) (*Notification, error) {
 		OrderNo: notify.OutTradeNo,
 		Amount:  int64(tool.FormatStringToFloat(notify.TotalAmount) * 100),
 		Status:  Status(notify.TradeStatus),
+		TradeNo: notify.TradeNo,
 	}, nil
 }


### PR DESCRIPTION
This PR fixes a bug where the external `trade_no` (such as Alipay TradeNo, EPay TradeNo, Stripe PaymentIntent ID) is not saved into the database's `order.trade_no` field during payment notifications. 

Changes included:
- Added `UpdateOrderStatusAndTradeNo` to the order model.
- Extracted `TradeNo` from the Alipay notification payload in `pkg/payment/alipay`.
- Updated Alipay, EPay, and Stripe notification logic to save the `TradeNo` along with the completed status.

This allows administrators to easily reconcile payments and process refunds.