### PR TITLE
fix(order): 修复流量重置时赠送金额未被扣除导致可无限免费重置的问题

### DIFF
--- a/internal/logic/public/order/resetTrafficLogic.go
+++ b/internal/logic/public/order/resetTrafficLogic.go
@@ -60,8 +60,8 @@ func (l *ResetTrafficLogic) ResetTraffic(req *dto.ResetTrafficOrderRequest) (res
 	if u.GiftAmount > 0 {
 		if u.GiftAmount >= amount {
 			deductionAmount = amount
-			amount = 0
 			u.GiftAmount -= amount
+			amount = 0
 		} else {
 			deductionAmount = u.GiftAmount
 			amount -= u.GiftAmount


### PR DESCRIPTION
## 问题

`ResetTraffic`（流量重置下单）中，当用户的赠送金额足以覆盖重置费用时，赠送金额**不会被扣除**。

https://github.com/perfect-panel/backend/blob/master/internal/logic/public/order/resetTrafficLogic.go#L60-L70

```go
amount := userSubscribe.Subscribe.Replacement
var deductionAmount int64
if u.GiftAmount > 0 {
    if u.GiftAmount >= amount {
        deductionAmount = amount
        amount = 0              // ← amount 先被置为 0
        u.GiftAmount -= amount  // ← 这里减去的是 0，赠送金额没有变化
    } else {
        deductionAmount = u.GiftAmount
        amount -= u.GiftAmount
        u.GiftAmount = 0
    }
}
```

`amount = 0` 执行在 `u.GiftAmount -= amount` 之前，因此实际减去的是 `0`，`u.GiftAmount` 保持原值。

随后该用户对象会被持久化（`txStore.User().Update(l.ctx, u)`），订单也以「已由赠送金额抵扣」的形式创建：

```go
Type:       3,
Price:      userSubscribe.Subscribe.Replacement,
Amount:     amount + feeAmount,   // amount 为 0
GiftAmount: deductionAmount,      // 记录了抵扣额
```

## 影响

只要用户的**赠送金额 ≥ 流量重置费用**，就可以**无限次免费重置流量**：每次下单都会按「赠送金额已支付」成立并重置流量，但赠送金额余额始终不减少。

`GiftAmount < amount` 的分支是正确的（`u.GiftAmount = 0`），所以问题只出现在赠送金额足够支付的场景。

## 修复

将扣除赠送金额的语句移到 `amount = 0` 之前：

```go
if u.GiftAmount >= amount {
    deductionAmount = amount
    u.GiftAmount -= amount
    amount = 0
}
```

## 补充

仓库内其余三处赠送金额抵扣的实现均正确，可作为对照：

- `internal/logic/public/order/purchaseLogic.go:240` — `u.GiftAmount -= orderInfo.GiftAmount`
- `internal/logic/public/order/renewalLogic.go:139` — `u.GiftAmount -= deductionAmount`
- `internal/logic/public/portal/purchaseCheckoutLogic.go:458` — `userInfo.GiftAmount -= giftUsed`

本次改动仅调整两行语句的顺序，不涉及任何行为或接口变更。
