### PR TITLE
fix(user): 移除 user_subscribe_id 的 string tag，修复后台删除订阅必定失败 (#188)

### DIFF
--- a/internal/model/dto/user.go
+++ b/internal/model/dto/user.go
@@ -49,7 +49,7 @@ type DeleteUserDeivceRequest struct {
 }
 
 type DeleteUserSubscribeRequest struct {
-	UserSubscribeId int64 `json:"user_subscribe_id,string"`
+	UserSubscribeId int64 `json:"user_subscribe_id"`
 }
 
 type GetUserAuthMethodRequest struct {


### PR DESCRIPTION
修复 #188。

## 问题

后台「用户管理 → 订阅列表 → 删除订阅」**必定失败**，返回 400「请求参数不正确」。

`DeleteUserSubscribeRequest` 的 `user_subscribe_id` 带了 `,string` tag，要求 JSON 中以字符串传递：

https://github.com/perfect-panel/backend/blob/master/internal/model/dto/user.go#L51-L53

```go
type DeleteUserSubscribeRequest struct {
	UserSubscribeId int64 `json:"user_subscribe_id,string"`
}
```

而前端传的是数字（`packages/ui/src/services/admin/typings.d.ts`）：

```ts
user_subscribe_id: number;
```

导致 JSON 解析在数字处直接语法报错，请求根本进不到业务逻辑。

## 为什么判断是误加

`,string` 是**整个 `internal/model/dto/` 目录下的唯一一处**。同一个 `user.go` 里 `UserSubscribeId` 共出现 7 次，其余 6 处均为普通 `int64`：

```go
52:  UserSubscribeId int64  `json:"user_subscribe_id,string"`   // ← 唯一带 ,string
143: UserSubscribeId int64  `json:"user_subscribe_id"`
147: UserSubscribeId int64  `json:"user_subscribe_id"`
210: UserSubscribeId int64  `json:"user_subscribe_id" validate:"required"`
215: UserSubscribeId int64  `json:"user_subscribe_id"`
323: UserSubscribeId int64  `json:"user_subscribe_id"`
```

因此 `,string` 并非项目约定。

## 实测对照

对 `DELETE /v1/admin/user/subscribe`：

```bash
# A) 传数字（前端当前行为）
-d '{"user_subscribe_id":6847}'
# {"code":400,"msg":"\"Syntax error at index 26: invalid char\n\n\t{\"user_subscribe_id\":6847}\n\t^\n\""}
#                                    ↑ index 26 正好指在 6847 上

# B) 传字符串
-d '{"user_subscribe_id":"99999999"}'
# {"code":10001,"msg":"Database query error"}   ← 已通过参数校验，进入业务逻辑
#                                                  （报错仅因故意使用不存在的 id）
```

## 改动

移除 `,string`，与其余 6 处保持一致。**前端无需改动**。

## 验证

- `go build ./internal/...` 通过
- `go vet ./internal/model/dto/` 通过
- 改动后 `internal/model/dto/` 下 `,string` 数量为 0

仅一行改动，不涉及任何行为或接口语义变更。
