### PR TITLE
fix(user): validate subscription ownership in refund endpoints

### DIFF
--- a/internal/logic/public/user/preUnsubscribeLogic.go
+++ b/internal/logic/public/user/preUnsubscribeLogic.go
@@ -4,8 +4,12 @@ import (
 	"context"
 
 	"github.com/perfect-panel/server/internal/model/dto"
+	usermodel "github.com/perfect-panel/server/internal/model/entity/user"
 	"github.com/perfect-panel/server/internal/svc"
+	"github.com/perfect-panel/server/pkg/constant"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/xerr"
+	"github.com/pkg/errors"
 )
 
 type PreUnsubscribeLogic struct {
@@ -24,6 +28,23 @@ func NewPreUnsubscribeLogic(ctx context.Context, svcCtx *svc.ServiceContext) *Pr
 }
 
 func (l *PreUnsubscribeLogic) PreUnsubscribe(req *dto.PreUnsubscribeRequest) (resp *dto.PreUnsubscribeResponse, err error) {
+	u, ok := l.ctx.Value(constant.CtxKeyUser).(*usermodel.User)
+	if !ok {
+		return nil, errors.Wrapf(xerr.NewErrCode(xerr.InvalidAccess), "Invalid Access")
+	}
+
+	userSub, err := l.svcCtx.Store.User().FindOneSubscribe(l.ctx, req.Id)
+	if err != nil {
+		l.Errorw("[PreUnsubscribeLogic] FindOneSubscribe failed", logger.Field("err", err.Error()), logger.Field("reqId", req.Id))
+		return nil, errors.Wrapf(xerr.NewErrCode(xerr.DatabaseQueryError), "FindOneSubscribe failed: %v", err.Error())
+	}
+	if userSub.UserId != u.Id {
+		l.Errorw("[PreUnsubscribeLogic] User subscribe does not belong to current user",
+			logger.Field("userSubscribeId", userSub.Id),
+			logger.Field("userId", u.Id))
+		return nil, errors.Wrapf(xerr.NewErrCode(xerr.InvalidAccess), "user subscribe does not belong to current user")
+	}
+
 	remainingAmount, err := CalculateRemainingAmount(l.ctx, l.svcCtx, req.Id)
 	if err != nil {
 		l.Errorw("[PreUnsubscribeLogic] Calculate Remaining Amount Error:", logger.Field("err", err.Error()))

--- a/internal/logic/public/user/refundAuthorization_test.go
+++ b/internal/logic/public/user/refundAuthorization_test.go
@@ -1,0 +1,210 @@
+package user
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pkg/errors"
+
+	"github.com/perfect-panel/server/internal/config"
+	"github.com/perfect-panel/server/internal/model/dto"
+	usermodel "github.com/perfect-panel/server/internal/model/entity/user"
+	"github.com/perfect-panel/server/internal/repository"
+	"github.com/perfect-panel/server/internal/svc"
+	"github.com/perfect-panel/server/pkg/constant"
+	"github.com/perfect-panel/server/pkg/logger/logtest"
+	"github.com/perfect-panel/server/pkg/xerr"
+)
+
+// fakeUserRepo embeds repository.UserRepo (nil) so any unexpected
+// method call panics immediately (fail-fast).
+type fakeUserRepo struct {
+	repository.UserRepo
+
+	findOneSubscribeFn    func(context.Context, int64) (*usermodel.Subscribe, error)
+	findOneSubscribeCalls int
+
+	findOneUserSubscribeFn    func(context.Context, int64) (*usermodel.SubscribeDetails, error)
+	findOneUserSubscribeCalls int
+}
+
+func (r *fakeUserRepo) FindOneSubscribe(ctx context.Context, id int64) (*usermodel.Subscribe, error) {
+	r.findOneSubscribeCalls++
+	if r.findOneSubscribeFn != nil {
+		return r.findOneSubscribeFn(ctx, id)
+	}
+	panic("fakeUserRepo: unexpected call to FindOneSubscribe")
+}
+
+func (r *fakeUserRepo) FindOneUserSubscribe(ctx context.Context, id int64) (*usermodel.SubscribeDetails, error) {
+	r.findOneUserSubscribeCalls++
+	if r.findOneUserSubscribeFn != nil {
+		return r.findOneUserSubscribeFn(ctx, id)
+	}
+	panic("fakeUserRepo: unexpected call to FindOneUserSubscribe")
+}
+
+// fakeStore embeds repository.Store (nil) so any unexpected method
+// call panics immediately.
+type fakeStore struct {
+	repository.Store
+	uRepo repository.UserRepo
+}
+
+func (s *fakeStore) User() repository.UserRepo { return s.uRepo }
+
+func newFakeSvcCtx(uRepo repository.UserRepo) *svc.ServiceContext {
+	return &svc.ServiceContext{
+		Store:  &fakeStore{uRepo: uRepo},
+		Config: config.Config{},
+	}
+}
+
+// errCode extracts the xerr.CodeError from the wrapped error chain.
+func errCode(t *testing.T, err error) uint32 {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var ce *xerr.CodeError
+	if !errors.As(errors.Cause(err), &ce) {
+		t.Fatalf("expected *xerr.CodeError in chain, got %T", err)
+	}
+	return ce.GetErrCode()
+}
+
+// ---------------------------------------------------------------------------
+// PreUnsubscribe – authorization-gate tests
+// ---------------------------------------------------------------------------
+
+func TestPreUnsubscribe_WrongOwner_ReturnsInvalidAccess(t *testing.T) {
+	logtest.Discard(t)
+
+	ctx := context.WithValue(context.Background(), constant.CtxKeyUser, &usermodel.User{Id: 100})
+	const subID int64 = 200
+
+	u := &fakeUserRepo{
+		findOneSubscribeFn: func(_ context.Context, id int64) (*usermodel.Subscribe, error) {
+			if id != subID {
+				t.Fatalf("FindOneSubscribe: got id %d, want %d", id, subID)
+			}
+			return &usermodel.Subscribe{Id: subID, UserId: 200}, nil
+		},
+	}
+
+	logic := NewPreUnsubscribeLogic(ctx, newFakeSvcCtx(u))
+	resp, err := logic.PreUnsubscribe(&dto.PreUnsubscribeRequest{Id: subID})
+
+	if code := errCode(t, err); code != xerr.InvalidAccess {
+		t.Fatalf("code = %d, want %d (InvalidAccess)", code, xerr.InvalidAccess)
+	}
+	if resp != nil {
+		t.Fatalf("resp = %+v, want nil", resp)
+	}
+	if u.findOneSubscribeCalls != 1 {
+		t.Fatalf("FindOneSubscribe called %d time(s), want 1", u.findOneSubscribeCalls)
+	}
+	if u.findOneUserSubscribeCalls != 0 {
+		t.Fatalf("FindOneUserSubscribe called %d time(s), want 0", u.findOneUserSubscribeCalls)
+	}
+}
+
+func TestPreUnsubscribe_OwnerBypassesAuthGate(t *testing.T) {
+	logtest.Discard(t)
+
+	ctx := context.WithValue(context.Background(), constant.CtxKeyUser, &usermodel.User{Id: 100})
+	const subID int64 = 100
+
+	u := &fakeUserRepo{
+		findOneSubscribeFn: func(_ context.Context, id int64) (*usermodel.Subscribe, error) {
+			if id != subID {
+				t.Fatalf("FindOneSubscribe: got id %d, want %d", id, subID)
+			}
+			return &usermodel.Subscribe{Id: subID, UserId: 100}, nil
+		},
+		findOneUserSubscribeFn: func(_ context.Context, id int64) (*usermodel.SubscribeDetails, error) {
+			return nil, errors.New("simulated FindOneUserSubscribe failure")
+		},
+	}
+
+	logic := NewPreUnsubscribeLogic(ctx, newFakeSvcCtx(u))
+	resp, err := logic.PreUnsubscribe(&dto.PreUnsubscribeRequest{Id: subID})
+
+	if code := errCode(t, err); code == xerr.InvalidAccess {
+		t.Fatal("got InvalidAccess – auth gate should not have blocked the owner")
+	}
+	if resp != nil {
+		t.Fatalf("resp = %+v, want nil (expected downstream error)", resp)
+	}
+	if u.findOneSubscribeCalls != 1 {
+		t.Fatalf("FindOneSubscribe called %d time(s), want 1", u.findOneSubscribeCalls)
+	}
+	if u.findOneUserSubscribeCalls != 1 {
+		t.Fatalf("FindOneUserSubscribe called %d time(s), want 1", u.findOneUserSubscribeCalls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unsubscribe – authorization-gate tests
+// ---------------------------------------------------------------------------
+
+func TestUnsubscribe_WrongOwner_ReturnsInvalidAccess(t *testing.T) {
+	logtest.Discard(t)
+
+	ctx := context.WithValue(context.Background(), constant.CtxKeyUser, &usermodel.User{Id: 100})
+	const subID int64 = 200
+
+	u := &fakeUserRepo{
+		findOneSubscribeFn: func(_ context.Context, id int64) (*usermodel.Subscribe, error) {
+			if id != subID {
+				t.Fatalf("FindOneSubscribe: got id %d, want %d", id, subID)
+			}
+			return &usermodel.Subscribe{Id: subID, UserId: 200, Status: 1}, nil
+		},
+	}
+
+	logic := NewUnsubscribeLogic(ctx, newFakeSvcCtx(u))
+	err := logic.Unsubscribe(&dto.UnsubscribeRequest{Id: subID})
+
+	if code := errCode(t, err); code != xerr.InvalidAccess {
+		t.Fatalf("code = %d, want %d (InvalidAccess)", code, xerr.InvalidAccess)
+	}
+	if u.findOneSubscribeCalls != 1 {
+		t.Fatalf("FindOneSubscribe called %d time(s), want 1", u.findOneSubscribeCalls)
+	}
+	if u.findOneUserSubscribeCalls != 0 {
+		t.Fatalf("FindOneUserSubscribe called %d time(s), want 0", u.findOneUserSubscribeCalls)
+	}
+}
+
+func TestUnsubscribe_OwnerBypassesAuthGate(t *testing.T) {
+	logtest.Discard(t)
+
+	ctx := context.WithValue(context.Background(), constant.CtxKeyUser, &usermodel.User{Id: 100})
+	const subID int64 = 100
+
+	u := &fakeUserRepo{
+		findOneSubscribeFn: func(_ context.Context, id int64) (*usermodel.Subscribe, error) {
+			if id != subID {
+				t.Fatalf("FindOneSubscribe: got id %d, want %d", id, subID)
+			}
+			return &usermodel.Subscribe{Id: subID, UserId: 100, Status: 1}, nil
+		},
+		findOneUserSubscribeFn: func(_ context.Context, id int64) (*usermodel.SubscribeDetails, error) {
+			return nil, errors.New("simulated FindOneUserSubscribe failure")
+		},
+	}
+
+	logic := NewUnsubscribeLogic(ctx, newFakeSvcCtx(u))
+	err := logic.Unsubscribe(&dto.UnsubscribeRequest{Id: subID})
+
+	if code := errCode(t, err); code == xerr.InvalidAccess {
+		t.Fatal("got InvalidAccess – auth gate should not have blocked the owner")
+	}
+	if u.findOneSubscribeCalls != 1 {
+		t.Fatalf("FindOneSubscribe called %d time(s), want 1", u.findOneSubscribeCalls)
+	}
+	if u.findOneUserSubscribeCalls != 1 {
+		t.Fatalf("FindOneUserSubscribe called %d time(s), want 1", u.findOneUserSubscribeCalls)
+	}
+}

--- a/internal/logic/public/user/unsubscribeLogic.go
+++ b/internal/logic/public/user/unsubscribeLogic.go
@@ -49,6 +49,12 @@ func (l *UnsubscribeLogic) Unsubscribe(req *dto.UnsubscribeRequest) error {
 		l.Errorw("FindOneSubscribe failed", logger.Field("error", err.Error()), logger.Field("reqId", req.Id))
 		return errors.Wrapf(xerr.NewErrCode(xerr.DatabaseQueryError), "FindOneSubscribe failed: %v", err.Error())
 	}
+	if userSub.UserId != u.Id {
+		l.Errorw("User subscribe does not belong to current user",
+			logger.Field("userSubscribeId", userSub.Id),
+			logger.Field("userId", u.Id))
+		return errors.Wrapf(xerr.NewErrCode(xerr.InvalidAccess), "user subscribe does not belong to current user")
+	}
 
 	activate := []uint8{0, 1, 2}
 


### PR DESCRIPTION
Fixes #192

## Summary

- validate subscription ownership before refund previews
- validate subscription ownership before cancelling subscriptions
- prevent unauthorized refunds

## Tests

- `go test ./internal/logic/public/user`
- `go test ./internal/handler/public/user`