### PR TITLE
fix(user): allow cancelling admin-created subscriptions

### DIFF
--- a/internal/logic/public/user/adminCreatedSubscriptionCancellation_test.go
+++ b/internal/logic/public/user/adminCreatedSubscriptionCancellation_test.go
@@ -1,0 +1,149 @@
+package user
+
+import (
+	"context"
+	"testing"
+
+	"github.com/perfect-panel/server/internal/model/dto"
+	usermodel "github.com/perfect-panel/server/internal/model/entity/user"
+	"github.com/perfect-panel/server/internal/repository"
+	"github.com/perfect-panel/server/internal/svc"
+	"github.com/perfect-panel/server/pkg/constant"
+	"github.com/perfect-panel/server/pkg/logger/logtest"
+	"gorm.io/gorm"
+)
+
+type adminCreatedSubscriptionUserRepo struct {
+	repository.UserRepo
+
+	subscribe                 *usermodel.Subscribe
+	findOneSubscribeCalls     int
+	findOneUserSubscribeCalls int
+	updateSubscribeCalls      int
+	clearSubscribeCacheCalls  int
+}
+
+func (r *adminCreatedSubscriptionUserRepo) FindOneSubscribe(_ context.Context, _ int64) (*usermodel.Subscribe, error) {
+	r.findOneSubscribeCalls++
+	return r.subscribe, nil
+}
+
+func (r *adminCreatedSubscriptionUserRepo) FindOneUserSubscribe(_ context.Context, _ int64) (*usermodel.SubscribeDetails, error) {
+	r.findOneUserSubscribeCalls++
+	return &usermodel.SubscribeDetails{OrderId: r.subscribe.OrderId}, nil
+}
+
+func (r *adminCreatedSubscriptionUserRepo) UpdateSubscribe(_ context.Context, subscribe *usermodel.Subscribe, _ ...*gorm.DB) error {
+	r.updateSubscribeCalls++
+	r.subscribe = subscribe
+	return nil
+}
+
+func (r *adminCreatedSubscriptionUserRepo) ClearSubscribeCache(_ context.Context, _ ...*usermodel.Subscribe) error {
+	r.clearSubscribeCacheCalls++
+	return nil
+}
+
+type adminCreatedSubscriptionSubscribeRepo struct {
+	repository.SubscribeRepo
+	clearCacheCalls int
+}
+
+func (r *adminCreatedSubscriptionSubscribeRepo) ClearCache(_ context.Context, _ ...int64) error {
+	r.clearCacheCalls++
+	return nil
+}
+
+type adminCreatedSubscriptionStore struct {
+	repository.Store
+
+	userRepo      repository.UserRepo
+	subscribeRepo repository.SubscribeRepo
+	inTxCalls     int
+	orderCalls    int
+}
+
+func (s *adminCreatedSubscriptionStore) User() repository.UserRepo {
+	return s.userRepo
+}
+
+func (s *adminCreatedSubscriptionStore) Subscribe() repository.SubscribeRepo {
+	return s.subscribeRepo
+}
+
+func (s *adminCreatedSubscriptionStore) Order() repository.OrderRepo {
+	s.orderCalls++
+	panic("admin-created subscription cancellation must not query an order")
+}
+
+func (s *adminCreatedSubscriptionStore) InTx(ctx context.Context, fn func(repository.Store) error) error {
+	s.inTxCalls++
+	return fn(s)
+}
+
+func TestUnsubscribe_AdminCreatedSubscription_SkipsRefund(t *testing.T) {
+	logtest.Discard(t)
+
+	const (
+		userID      int64 = 100
+		subscribeID int64 = 200
+		planID      int64 = 300
+	)
+
+	currentUser := &usermodel.User{
+		Id:         userID,
+		Balance:    1_000,
+		GiftAmount: 200,
+	}
+	userSubscribe := &usermodel.Subscribe{
+		Id:          subscribeID,
+		UserId:      userID,
+		OrderId:     0,
+		SubscribeId: planID,
+		Status:      1,
+	}
+	userRepo := &adminCreatedSubscriptionUserRepo{subscribe: userSubscribe}
+	subscribeRepo := &adminCreatedSubscriptionSubscribeRepo{}
+	store := &adminCreatedSubscriptionStore{
+		userRepo:      userRepo,
+		subscribeRepo: subscribeRepo,
+	}
+	ctx := context.WithValue(context.Background(), constant.CtxKeyUser, currentUser)
+	logic := NewUnsubscribeLogic(ctx, &svc.ServiceContext{Store: store})
+
+	err := logic.Unsubscribe(&dto.UnsubscribeRequest{Id: subscribeID})
+
+	if err != nil {
+		t.Fatalf("Unsubscribe() error = %v, want nil", err)
+	}
+	if userRepo.subscribe.Status != 4 {
+		t.Fatalf("subscription status = %d, want 4 (cancelled)", userRepo.subscribe.Status)
+	}
+	if currentUser.Balance != 1_000 {
+		t.Fatalf("user balance = %d, want 1000", currentUser.Balance)
+	}
+	if currentUser.GiftAmount != 200 {
+		t.Fatalf("user gift amount = %d, want 200", currentUser.GiftAmount)
+	}
+	if store.inTxCalls != 1 {
+		t.Fatalf("InTx called %d time(s), want 1", store.inTxCalls)
+	}
+	if store.orderCalls != 0 {
+		t.Fatalf("Order called %d time(s), want 0", store.orderCalls)
+	}
+	if userRepo.findOneSubscribeCalls != 1 {
+		t.Fatalf("FindOneSubscribe called %d time(s), want 1", userRepo.findOneSubscribeCalls)
+	}
+	if userRepo.findOneUserSubscribeCalls != 1 {
+		t.Fatalf("FindOneUserSubscribe called %d time(s), want 1", userRepo.findOneUserSubscribeCalls)
+	}
+	if userRepo.updateSubscribeCalls != 1 {
+		t.Fatalf("UpdateSubscribe called %d time(s), want 1", userRepo.updateSubscribeCalls)
+	}
+	if userRepo.clearSubscribeCacheCalls != 1 {
+		t.Fatalf("ClearSubscribeCache called %d time(s), want 1", userRepo.clearSubscribeCacheCalls)
+	}
+	if subscribeRepo.clearCacheCalls != 1 {
+		t.Fatalf("Subscribe.ClearCache called %d time(s), want 1", subscribeRepo.clearCacheCalls)
+	}
+}

--- a/internal/logic/public/user/unsubscribeLogic.go
+++ b/internal/logic/public/user/unsubscribeLogic.go
@@ -77,6 +77,11 @@ func (l *UnsubscribeLogic) Unsubscribe(req *dto.UnsubscribeRequest) error {
 		if err = store.User().UpdateSubscribe(l.ctx, userSub); err != nil {
 			return err
 		}
+		// Subscriptions created by an administrator have no associated order.
+		// They can be cancelled, but there is no payment to refund.
+		if userSub.OrderId == 0 {
+			return nil
+		}
 
 		// Query the original order information to determine refund strategy
 		orderInfo, err := store.Order().FindOne(l.ctx, userSub.OrderId)


### PR DESCRIPTION
## Summary

Allow users to cancel subscriptions created for them by an administrator.

Administrator-created subscriptions have `order_id = 0`. The existing cancellation flow updates the subscription status and then unconditionally looks up the original order. That lookup fails for order ID 0 and rolls back the transaction, causing the cancellation request to fail.

## Changes

- Return successfully after updating an administrator-created subscription to cancelled status.
- Skip order lookup and refund processing when `order_id = 0` because no payment was made for the subscription.
- Keep the existing order lookup and refund behavior unchanged for purchased subscriptions.
- Keep the existing subscription ownership and status validation unchanged.
- Add a regression test for cancelling an administrator-created subscription.

## Result

Administrator-created subscriptions can now be cancelled by their owners without creating a refund or changing account balances. Purchased subscriptions continue to use the existing refund path.

## Testing

- `go test ./internal/logic/public/user`
- The regression test verifies that the subscription is marked as cancelled.
- The regression test verifies that no order is queried and no refund changes the user's balance or gift balance.
- The regression test verifies that the affected subscription caches are cleared after cancellation.

Fixes #194 