### PR TITLE
fix(order): distinguish renewal previews from new-purchase quota checks

### DIFF
--- a/internal/logic/public/order/preCreateOrderLogic.go
+++ b/internal/logic/public/order/preCreateOrderLogic.go
@@ -56,7 +56,32 @@ func (l *PreCreateOrderLogic) PreCreateOrder(req *dto.PurchaseOrderRequest) (res
 		return nil, errors.Wrapf(xerr.NewErrCode(xerr.DatabaseQueryError), "find subscribe error: %v", err.Error())
 	}
 
-	if sub.Quota > 0 {
+	if req.UserSubscribeId < 0 {
+		return nil, errors.Wrapf(xerr.NewErrCode(xerr.InvalidParams), "invalid user subscribe id")
+	}
+	if req.UserSubscribeId > 0 {
+		userSubscribe, err := store.UserSubscription().FindOneSubscribe(l.ctx, req.UserSubscribeId)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, errors.Wrapf(xerr.NewErrCode(xerr.InvalidParams), "user subscribe not found")
+			}
+			l.Errorw("[PreCreateOrder] Database query error",
+				logger.Field("error", err.Error()),
+				logger.Field("user_subscribe_id", req.UserSubscribeId))
+			return nil, errors.Wrapf(xerr.NewErrCode(xerr.DatabaseQueryError), "find user subscribe error: %v", err.Error())
+		}
+		if userSubscribe.UserId != u.Id {
+			return nil, errors.Wrapf(xerr.NewErrCode(xerr.InvalidAccess), "user subscribe does not belong to current user")
+		}
+		if userSubscribe.SubscribeId != req.SubscribeId {
+			return nil, errors.Wrapf(xerr.NewErrCode(xerr.InvalidParams), "user subscribe does not match subscribe plan")
+		}
+		if userSubscribe.Status == user.SubscribeStatusDeducted {
+			return nil, errors.Wrapf(xerr.NewErrCode(xerr.InvalidParams), "user subscribe status does not allow renewal")
+		}
+	}
+
+	if sub.Quota > 0 && req.UserSubscribeId == 0 {
 		count, err := store.UserSubscription().CountQuotaConsumingSubscriptions(l.ctx, u.Id, req.SubscribeId)
 		if err != nil {
 			l.Errorw("[PreCreateOrder] Database query error", logger.Field("error", err.Error()), logger.Field("user_id", u.Id), logger.Field("subscribe_id", req.SubscribeId))

--- a/internal/logic/public/order/subscription_policy_test.go
+++ b/internal/logic/public/order/subscription_policy_test.go
@@ -29,10 +29,12 @@ func (s subscriptionPolicyStore) Subscribe() repository.SubscribeRepo { return s
 type subscriptionPolicyUserRepo struct {
 	repository.UserRepo
 	repository.UserSubscriptionRepo
-	blocking         bool
-	quotaCount       int64
-	hasBlockingCalls int
-	quotaCountCalls  int
+	blocking           bool
+	quotaCount         int64
+	subscription       *userEntity.Subscribe
+	hasBlockingCalls   int
+	quotaCountCalls    int
+	findSubscribeCalls int
 }
 
 func (r *subscriptionPolicyUserRepo) HasBlockingSubscription(_ context.Context, _ int64) (bool, error) {
@@ -43,6 +45,11 @@ func (r *subscriptionPolicyUserRepo) HasBlockingSubscription(_ context.Context, 
 func (r *subscriptionPolicyUserRepo) CountQuotaConsumingSubscriptions(_ context.Context, _ int64, _ int64) (int64, error) {
 	r.quotaCountCalls++
 	return r.quotaCount, nil
+}
+
+func (r *subscriptionPolicyUserRepo) FindOneSubscribe(_ context.Context, _ int64) (*userEntity.Subscribe, error) {
+	r.findSubscribeCalls++
+	return r.subscription, nil
 }
 
 type subscriptionPolicySubscribeRepo struct {
@@ -130,6 +137,108 @@ func TestPurchaseAndPreCreateUseQuotaConsumingCount(t *testing.T) {
 			t.Fatalf("CountQuotaConsumingSubscriptions calls = %d, want 1", users.quotaCountCalls)
 		}
 	})
+}
+
+func TestRenewalPreviewSkipsNewPurchaseQuotaAfterValidation(t *testing.T) {
+	users := &subscriptionPolicyUserRepo{
+		quotaCount: 1,
+		subscription: &userEntity.Subscribe{
+			Id:          22,
+			UserId:      42,
+			SubscribeId: 10,
+			Status:      userEntity.SubscribeStatusExpired,
+		},
+	}
+	logic := NewPreCreateOrderLogic(subscriptionPolicyContext(), &svc.ServiceContext{Store: subscriptionPolicyStore{
+		users: users,
+		subscribes: &subscriptionPolicySubscribeRepo{subscribe: &subscribe.Subscribe{
+			Id:        10,
+			Quota:     1,
+			UnitPrice: 100,
+		}},
+	}})
+
+	_, err := logic.PreCreateOrder(&dto.PurchaseOrderRequest{
+		SubscribeId:     10,
+		UserSubscribeId: 22,
+		Quantity:        1,
+	})
+	if err != nil {
+		t.Fatalf("PreCreateOrder renewal preview error = %v, want nil", err)
+	}
+	if users.findSubscribeCalls != 1 {
+		t.Fatalf("FindOneSubscribe calls = %d, want 1", users.findSubscribeCalls)
+	}
+	if users.quotaCountCalls != 0 {
+		t.Fatalf("CountQuotaConsumingSubscriptions calls = %d, want 0", users.quotaCountCalls)
+	}
+}
+
+func TestRenewalPreviewValidatesTargetBeforeSkippingQuota(t *testing.T) {
+	tests := []struct {
+		name         string
+		subscription *userEntity.Subscribe
+		wantError    string
+	}{
+		{
+			name: "foreign subscription",
+			subscription: &userEntity.Subscribe{
+				Id:          22,
+				UserId:      7,
+				SubscribeId: 10,
+				Status:      userEntity.SubscribeStatusActive,
+			},
+			wantError: "does not belong to current user",
+		},
+		{
+			name: "different plan",
+			subscription: &userEntity.Subscribe{
+				Id:          22,
+				UserId:      42,
+				SubscribeId: 11,
+				Status:      userEntity.SubscribeStatusActive,
+			},
+			wantError: "does not match subscribe plan",
+		},
+		{
+			name: "deducted subscription",
+			subscription: &userEntity.Subscribe{
+				Id:          22,
+				UserId:      42,
+				SubscribeId: 10,
+				Status:      userEntity.SubscribeStatusDeducted,
+			},
+			wantError: "status does not allow renewal",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			users := &subscriptionPolicyUserRepo{
+				quotaCount:   1,
+				subscription: tt.subscription,
+			}
+			logic := NewPreCreateOrderLogic(subscriptionPolicyContext(), &svc.ServiceContext{Store: subscriptionPolicyStore{
+				users: users,
+				subscribes: &subscriptionPolicySubscribeRepo{subscribe: &subscribe.Subscribe{
+					Id:    10,
+					Quota: 1,
+				}},
+			}})
+
+			_, err := logic.PreCreateOrder(&dto.PurchaseOrderRequest{
+				SubscribeId:     10,
+				UserSubscribeId: 22,
+				Quantity:        1,
+			})
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("PreCreateOrder error = %v, want %q", err, tt.wantError)
+			}
+			if users.quotaCountCalls != 0 {
+				t.Fatalf("CountQuotaConsumingSubscriptions calls = %d, want 0", users.quotaCountCalls)
+			}
+		})
+	}
 }
 
 func boolPtr(value bool) *bool { return &value }

--- a/internal/model/dto/order.go
+++ b/internal/model/dto/order.go
@@ -149,10 +149,11 @@ type PreRenewalOrderResponse struct {
 }
 
 type PurchaseOrderRequest struct {
-	SubscribeId int64  `json:"subscribe_id"`
-	Quantity    int64  `json:"quantity" validate:"required,gt=0,lte=1000"`
-	Payment     int64  `json:"payment,omitempty"`
-	Coupon      string `json:"coupon,omitempty"`
+	SubscribeId     int64  `json:"subscribe_id"`
+	Quantity        int64  `json:"quantity" validate:"required,gt=0,lte=1000"`
+	Payment         int64  `json:"payment,omitempty"`
+	Coupon          string `json:"coupon,omitempty"`
+	UserSubscribeId int64  `json:"user_subscribe_id,omitempty"`
 }
 
 type PurchaseOrderResponse struct {

--- a/ppanel.json
+++ b/ppanel.json
@@ -14403,6 +14403,9 @@
                 },
                 "subscribe_id": {
                     "type": "integer"
+                },
+                "user_subscribe_id": {
+                    "type": "integer"
                 }
             }
         },


### PR DESCRIPTION
Fixes #199

## Summary

This PR prevents `POST /v1/public/order/pre` from rejecting a valid renewal preview when the user has already reached the subscription plan quota.

The existing subscription being renewed already consumes a quota slot, but renewal does not create an additional subscription. Treating the preview as a new purchase therefore produces a false quota-limit error.

## Changes

- Detect renewal previews through `user_subscribe_id`.
- Reject negative subscription IDs.
- Validate that the renewal target exists.
- Verify that the target subscription belongs to the authenticated user.
- Verify that the target subscription belongs to the requested plan.
- Apply the same renewal-status policy used by the actual renewal endpoint.
- Run `CountQuotaConsumingSubscriptions` only for new-purchase previews.
- Preserve the existing quota policy for normal purchases.

## Security

The quota bypass is only applied after validating the referenced subscription.

This prevents a client from supplying:

- another user's subscription ID;
- a subscription ID belonging to another plan;
- a deducted/refunded subscription ID;
- an invalid or negative ID

to bypass the preview quota check.

The actual purchase and renewal endpoints continue performing their own authorization and business validation.

## Behavior

| Request | Plan quota state | Result |
| --- | --- | --- |
| New-purchase preview | Below quota | Allowed |
| New-purchase preview | At quota | Rejected |
| Valid renewal preview | At quota | Allowed |
| Renewal preview for another user | Any | Rejected |
| Renewal preview for another plan | Any | Rejected |
| Renewal preview for a deducted subscription | Any | Rejected |

## Tests

Add tests covering:

- new-purchase preview still calls the quota-count policy;
- valid renewal preview skips the new-purchase quota count;
- foreign subscription IDs are rejected;
- mismatched plan IDs are rejected;
- deducted subscriptions are rejected.