### PR TITLE
feat(subscription): give each client application default template params

### DIFF
--- a/initialize/migrate/database/mysql/02150_subscribe_application_default_params.down.sql
+++ b/initialize/migrate/database/mysql/02150_subscribe_application_default_params.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `subscribe_application`
+    DROP COLUMN `default_params`;

--- a/initialize/migrate/database/mysql/02150_subscribe_application_default_params.up.sql
+++ b/initialize/migrate/database/mysql/02150_subscribe_application_default_params.up.sql
@@ -1,0 +1,6 @@
+-- Template params were readable only from the subscription URL's query string,
+-- so a client whose template expects something like `mode=rule` had no way to
+-- receive it unless every user appended it by hand. Each application now carries
+-- its own defaults, which a request's query string still overrides.
+ALTER TABLE `subscribe_application`
+    ADD COLUMN `default_params` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '' COMMENT 'Default Template Params';

--- a/initialize/migrate/database/postgres/02150_subscribe_application_default_params.down.sql
+++ b/initialize/migrate/database/postgres/02150_subscribe_application_default_params.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "subscribe_application"
+    DROP COLUMN "default_params";

--- a/initialize/migrate/database/postgres/02150_subscribe_application_default_params.up.sql
+++ b/initialize/migrate/database/postgres/02150_subscribe_application_default_params.up.sql
@@ -1,0 +1,6 @@
+-- Template params were readable only from the subscription URL's query string,
+-- so a client whose template expects something like `mode=rule` had no way to
+-- receive it unless every user appended it by hand. Each application now carries
+-- its own defaults, which a request's query string still overrides.
+ALTER TABLE "subscribe_application"
+    ADD COLUMN "default_params" varchar(255) NOT NULL DEFAULT '';

--- a/internal/model/dto/client.go
+++ b/internal/model/dto/client.go
@@ -39,15 +39,19 @@ type ApplicationVersion struct {
 }
 
 type CreateSubscribeApplicationRequest struct {
-	Name              string       `json:"name"`
-	Description       string       `json:"description,omitempty"`
-	Icon              string       `json:"icon,omitempty"`
-	Scheme            string       `json:"scheme,omitempty"`
-	UserAgent         string       `json:"user_agent"`
-	IsDefault         bool         `json:"is_default"`
-	SubscribeTemplate string       `json:"template"`
-	OutputFormat      string       `json:"output_format"`
-	DownloadLink      DownloadLink `json:"download_link"`
+	Name              string `json:"name"`
+	Description       string `json:"description,omitempty"`
+	Icon              string `json:"icon,omitempty"`
+	Scheme            string `json:"scheme,omitempty"`
+	UserAgent         string `json:"user_agent"`
+	IsDefault         bool   `json:"is_default"`
+	SubscribeTemplate string `json:"template"`
+	OutputFormat      string `json:"output_format"`
+	// DefaultParams holds the template params this client should receive when the
+	// subscription URL does not carry them, in query-string form such as
+	// "mode=rule&emoji=1".
+	DefaultParams string       `json:"default_params,omitempty"`
+	DownloadLink  DownloadLink `json:"download_link"`
 }
 
 type DeleteSubscribeApplicationRequest struct {
@@ -96,6 +100,7 @@ type SubscribeApplication struct {
 	IsDefault         bool         `json:"is_default"`
 	SubscribeTemplate string       `json:"template"`
 	OutputFormat      string       `json:"output_format"`
+	DefaultParams     string       `json:"default_params,omitempty"`
 	DownloadLink      DownloadLink `json:"download_link,omitempty"`
 	CreatedAt         int64        `json:"created_at"`
 	UpdatedAt         int64        `json:"updated_at"`
@@ -121,5 +126,6 @@ type UpdateSubscribeApplicationRequest struct {
 	IsDefault         bool         `json:"is_default"`
 	SubscribeTemplate string       `json:"template"`
 	OutputFormat      string       `json:"output_format"`
+	DefaultParams     string       `json:"default_params,omitempty"`
 	DownloadLink      DownloadLink `json:"download_link,omitempty"`
 }

--- a/internal/module/platform/entity/client/application.go
+++ b/internal/module/platform/entity/client/application.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"net/url"
 	"time"
 )
 
@@ -15,6 +16,7 @@ type SubscribeApplication struct {
 	IsDefault         bool      `gorm:"type:tinyint(1);not null;default:0;comment:Is Default Application"`
 	SubscribeTemplate string    `gorm:"type:MEDIUMTEXT;default:null;comment:Subscribe Template"`
 	OutputFormat      string    `gorm:"type:varchar(50);default:'yaml';not null;comment:Output Format"`
+	DefaultParams     string    `gorm:"type:varchar(255);default:'';not null;comment:Default Template Params"`
 	DownloadLink      string    `gorm:"type:text;not null;comment:Download Link"`
 	CreatedAt         time.Time `gorm:"<-:create;comment:Create Time"`
 	UpdatedAt         time.Time `gorm:"comment:Update Time"`
@@ -22,6 +24,24 @@ type SubscribeApplication struct {
 
 func (SubscribeApplication) TableName() string {
 	return "subscribe_application"
+}
+
+// DefaultParamValues parses DefaultParams, stored in query-string form such as
+// "mode=rule&emoji=1", into the map templates read. A repeated key keeps its
+// first value, matching how the subscription URL's own query string collapses.
+func (a *SubscribeApplication) DefaultParamValues() (map[string]string, error) {
+	if a == nil || a.DefaultParams == "" {
+		return nil, nil
+	}
+	values, err := url.ParseQuery(a.DefaultParams)
+	if err != nil {
+		return nil, err
+	}
+	params := make(map[string]string, len(values))
+	for key := range values {
+		params[key] = values.Get(key)
+	}
+	return params, nil
 }
 
 type DownloadLink struct {

--- a/internal/module/platform/entity/client/application_test.go
+++ b/internal/module/platform/entity/client/application_test.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDefaultParamValues(t *testing.T) {
+	cases := []struct {
+		name    string
+		stored  string
+		want    map[string]string
+		wantErr bool
+	}{
+		{name: "unset", stored: "", want: nil},
+		{name: "single", stored: "mode=rule", want: map[string]string{"mode": "rule"}},
+		{name: "several", stored: "mode=rule&emoji=1", want: map[string]string{"mode": "rule", "emoji": "1"}},
+		{name: "valueless key", stored: "emoji", want: map[string]string{"emoji": ""}},
+		{name: "escaped value", stored: "name=a%20b", want: map[string]string{"name": "a b"}},
+		// The subscription URL's own query string keeps the first value of a
+		// repeated key, so the stored defaults have to agree.
+		{name: "repeated key keeps first", stored: "mode=rule&mode=global", want: map[string]string{"mode": "rule"}},
+		{name: "malformed escape", stored: "mode=%zz", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := &SubscribeApplication{DefaultParams: tc.stored}
+			got, err := app.DefaultParamValues()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("DefaultParamValues(%q) error = nil, want an error", tc.stored)
+				}
+				if got != nil {
+					t.Fatalf("DefaultParamValues(%q) = %v, want nil alongside the error", tc.stored, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("DefaultParamValues(%q) error = %v", tc.stored, err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("DefaultParamValues(%q) = %v, want %v", tc.stored, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDefaultParamValuesNilReceiver(t *testing.T) {
+	var app *SubscribeApplication
+	got, err := app.DefaultParamValues()
+	if err != nil || got != nil {
+		t.Fatalf("DefaultParamValues() = (%v, %v), want (nil, nil)", got, err)
+	}
+}

--- a/internal/module/subscription/internal/application/createSubscribeApplicationLogic.go
+++ b/internal/module/subscription/internal/application/createSubscribeApplicationLogic.go
@@ -43,6 +43,7 @@ func (l *CreateSubscribeApplicationLogic) CreateSubscribeApplication(req *dto.Cr
 		IsDefault:         req.IsDefault,
 		SubscribeTemplate: req.SubscribeTemplate,
 		OutputFormat:      req.OutputFormat,
+		DefaultParams:     req.DefaultParams,
 		DownloadLink:      string(linkData),
 	}
 

--- a/internal/module/subscription/internal/application/getSubscribeApplicationListLogic.go
+++ b/internal/module/subscription/internal/application/getSubscribeApplicationListLogic.go
@@ -47,6 +47,7 @@ func (l *GetSubscribeApplicationListLogic) GetSubscribeApplicationList(req *dto.
 			IsDefault:         item.IsDefault,
 			SubscribeTemplate: item.SubscribeTemplate,
 			OutputFormat:      item.OutputFormat,
+			DefaultParams:     item.DefaultParams,
 			DownloadLink:      temp,
 			CreatedAt:         item.CreatedAt.UnixMilli(),
 			UpdatedAt:         item.UpdatedAt.UnixMilli(),

--- a/internal/module/subscription/internal/application/previewSubscribeTemplateLogic.go
+++ b/internal/module/subscription/internal/application/previewSubscribeTemplateLogic.go
@@ -46,7 +46,15 @@ func (l *PreviewSubscribeTemplateLogic) PreviewSubscribeTemplate(req *dto.Previe
 		return nil, errors.Wrapf(xerr.NewErrCode(xerr.DatabaseQueryError), "FindOneClient error: %v", err.Error())
 	}
 
+	// Preview renders with the application's own defaults so it matches what a
+	// client receives when its subscription URL carries no params of its own.
+	defaultParams, err := data.DefaultParamValues()
+	if err != nil {
+		l.Errorf("[PreviewSubscribeTemplateLogic] Ignoring malformed default params %q: %v", data.DefaultParams, err)
+	}
+
 	sub := adapter.NewAdapter(data.SubscribeTemplate, adapter.WithServers(servers),
+		adapter.WithParams(defaultParams),
 		adapter.WithSiteName("PerfectPanel"),
 		adapter.WithSubscribeName("Test Subscribe"),
 		adapter.WithOutputFormat(data.OutputFormat),

--- a/internal/module/subscription/internal/application/updateSubscribeApplicationLogic.go
+++ b/internal/module/subscription/internal/application/updateSubscribeApplicationLogic.go
@@ -48,6 +48,7 @@ func (l *UpdateSubscribeApplicationLogic) UpdateSubscribeApplication(req *dto.Up
 	data.IsDefault = req.IsDefault
 	data.SubscribeTemplate = req.SubscribeTemplate
 	data.OutputFormat = req.OutputFormat
+	data.DefaultParams = req.DefaultParams
 	data.DownloadLink = string(linkData)
 	err = l.deps.Clients.Update(l.ctx, data)
 	if err != nil {

--- a/internal/module/subscription/internal/delivery/deliver.go
+++ b/internal/module/subscription/internal/delivery/deliver.go
@@ -108,6 +108,16 @@ func (l *SubscribeLogic) Handler(req *dto.SubscribeRequest) (resp *dto.Subscribe
 	if err != nil {
 		return nil, err
 	}
+	defaultParams, err := targetApp.DefaultParamValues()
+	if err != nil {
+		// A malformed default must not cost the user their subscription; fall back
+		// to whatever the request carried.
+		l.Errorw("[SubscribeLogic] Ignoring malformed default params",
+			logger.Field("application", targetApp.Name),
+			logger.Field("defaultParams", targetApp.DefaultParams),
+			logger.Field("error", err.Error()))
+	}
+
 	a := adapter.NewAdapter(
 		targetApp.SubscribeTemplate,
 		adapter.WithServers(servers),
@@ -123,7 +133,7 @@ func (l *SubscribeLogic) Handler(req *dto.SubscribeRequest) (resp *dto.Subscribe
 			Traffic:      userSubscribe.Traffic,
 			SubscribeURL: l.getSubscribeV2URL(),
 		}),
-		adapter.WithParams(req.Params),
+		adapter.WithParams(mergeParams(defaultParams, req.Params)),
 	)
 
 	logger.Debugf("[SubscribeLogic] Building client config for user %d with URI %s", userSubscribe.UserId, l.getSubscribeV2URL())

--- a/internal/module/subscription/internal/delivery/params.go
+++ b/internal/module/subscription/internal/delivery/params.go
@@ -1,0 +1,18 @@
+package delivery
+
+// mergeParams layers the subscription URL's query string over the client
+// application's stored defaults, so a template can rely on its own defaults while
+// any single one of them stays overridable per request.
+func mergeParams(defaults, requested map[string]string) map[string]string {
+	if len(defaults) == 0 {
+		return requested
+	}
+	merged := make(map[string]string, len(defaults)+len(requested))
+	for key, value := range defaults {
+		merged[key] = value
+	}
+	for key, value := range requested {
+		merged[key] = value
+	}
+	return merged
+}

--- a/internal/module/subscription/internal/delivery/params_test.go
+++ b/internal/module/subscription/internal/delivery/params_test.go
@@ -1,0 +1,58 @@
+package delivery
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeParams(t *testing.T) {
+	cases := []struct {
+		name      string
+		defaults  map[string]string
+		requested map[string]string
+		want      map[string]string
+	}{
+		{
+			name:      "no defaults returns the request untouched",
+			requested: map[string]string{"mode": "global"},
+			want:      map[string]string{"mode": "global"},
+		},
+		{
+			name:     "defaults apply when the request carries nothing",
+			defaults: map[string]string{"mode": "rule", "emoji": "1"},
+			want:     map[string]string{"mode": "rule", "emoji": "1"},
+		},
+		{
+			name:      "the request wins on a shared key",
+			defaults:  map[string]string{"mode": "rule", "emoji": "1"},
+			requested: map[string]string{"mode": "global"},
+			want:      map[string]string{"mode": "global", "emoji": "1"},
+		},
+		{
+			name:      "an empty request value still overrides",
+			defaults:  map[string]string{"emoji": "1"},
+			requested: map[string]string{"emoji": ""},
+			want:      map[string]string{"emoji": ""},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeParams(tc.defaults, tc.requested)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("mergeParams(%v, %v) = %v, want %v", tc.defaults, tc.requested, got, tc.want)
+			}
+		})
+	}
+}
+
+// The defaults map comes from the client application and is reused across
+// requests, so merging must not write into it.
+func TestMergeParamsDoesNotMutateDefaults(t *testing.T) {
+	defaults := map[string]string{"mode": "rule"}
+	mergeParams(defaults, map[string]string{"mode": "global", "emoji": "1"})
+
+	if want := map[string]string{"mode": "rule"}; !reflect.DeepEqual(defaults, want) {
+		t.Fatalf("defaults = %v after merging, want %v", defaults, want)
+	}
+}

--- a/ppanel.json
+++ b/ppanel.json
@@ -12007,6 +12007,10 @@
         "dto.CreateSubscribeApplicationRequest": {
             "type": "object",
             "properties": {
+                "default_params": {
+                    "description": "DefaultParams holds the template params this client should receive when the\nsubscription URL does not carry them, in query-string form such as\n\"mode=rule\u0026emoji=1\".",
+                    "type": "string"
+                },
                 "description": {
                     "type": "string"
                 },
@@ -15893,6 +15897,9 @@
                 "created_at": {
                     "type": "integer"
                 },
+                "default_params": {
+                    "type": "string"
+                },
                 "description": {
                     "type": "string"
                 },
@@ -16785,6 +16792,9 @@
         "dto.UpdateSubscribeApplicationRequest": {
             "type": "object",
             "properties": {
+                "default_params": {
+                    "type": "string"
+                },
                 "description": {
                     "type": "string"
                 },


### PR DESCRIPTION
Template params were only ever readable from the subscription URL's query string, so a template that expects `mode=rule` only got it if every user appended it by hand.

Each `subscribe_application` now carries its own `default_params` in query-string form, maintained next to the template in the admin editor. Delivery layers the request's query string over those defaults, so a per-request param still wins on any single key.

Defaults live with the application rather than in the subscribe config because the params a template understands are the template's own convention — a Clash template and a sing-box template accept different ones — and it keeps them out of the public global config, which DeepCopies the whole `dto.SubscribeConfig`.

- Migration `02150` (mysql + postgres, with down)
- Template preview renders with the same defaults
- Repeated keys keep the first value, matching how the handler collapses the URL query string
- A malformed default is logged and ignored rather than failing the subscription