### PR TITLE
fix(support): order ticket follows by creation time

### DIFF
--- a/internal/module/support/internal/repo/ticket.go
+++ b/internal/module/support/internal/repo/ticket.go
@@ -106,7 +106,9 @@ func (m *ticketRepo) Delete(ctx context.Context, id int64) error {
 func (m *ticketRepo) QueryTicketDetail(ctx context.Context, id int64) (*ticket.Details, error) {
 	var data *ticket.Details
 	err := m.QueryNoCacheCtx(ctx, &data, func(conn *gorm.DB, v interface{}) error {
-		return conn.Model(&ticket.Ticket{}).Where("id = ?", id).Preload("Follows").First(v).Error
+		return conn.Model(&ticket.Ticket{}).Where("id = ?", id).Preload("Follows", func(db *gorm.DB) *gorm.DB {
+			return db.Order("created_at ASC, id ASC")
+		}).First(v).Error
 	})
 	return data, err
 }


### PR DESCRIPTION
## 问题

工单详情里的回复记录顺序是乱的，不按时间先后排列。用户侧和管理侧的工单详情页都能复现，Telegram 机器人的工单卡片同样受影响。

## 原因

`QueryTicketDetail` 用的是不带排序的 `Preload("Follows")`：

```go
conn.Model(&ticket.Ticket{}).Where("id = ?", id).Preload("Follows").First(v)
```

GORM 为此发出的是 `SELECT * FROM ticket_follow WHERE ticket_id IN (?)`，**没有 ORDER BY**。SQL 不保证无序查询的返回顺序，数据库按自己选定的执行计划返回行。

这里还有一个放大因素：`ticket_follow` 建表时只有 `id` 主键，**`ticket_id` 上没有索引**（`00001_init_schema.up.sql:282`），所以这个查询走的是顺序扫描，返回的就是物理行顺序。表纯追加时物理顺序恰好接近插入顺序，看着"大部分时候是对的"；一旦页面被复用，顺序就散了。

实际观测到的返回顺序（时间已按相对量改写）：

```
#1  2026-01-01 12:42
#5  2026-01-24 04:17   ← 跳到 #4 前面
#4  2026-01-24 02:00
#6  2026-01-27 00:40
#7  2026-01-27 06:37
#3  2026-01-24 01:58   ← 被甩到最后
```

前端只是原样渲染这个数组，没有再排序，所以乱序直接呈现给用户和客服。

## 修改

给 Preload 加上显式排序：

```go
Preload("Follows", func(db *gorm.DB) *gorm.DB {
    return db.Order("created_at ASC, id ASC")
})
```

`created_at` 是 `TIMESTAMP(3)`，同一毫秒内仍可能有多条（例如一次事务里连续追加的系统记录），所以用 `id` 作为次级键保证结果稳定。

## 影响范围

`QueryTicketDetail` 是 `Follows` 的唯一加载点，三个消费方一并修复：

- `internal/module/support/internal/ticket/service.go:89` 用户侧工单详情
- `internal/module/support/internal/ticket/service.go:167` 管理侧工单详情
- `internal/module/notification/internal/telegram/admin.go:214` Telegram 工单卡片的"回复记录"

## 说明

- 只加排序，不改查询语义、不改返回结构，前端无需配合改动。
- 无需迁移。排序只作用在单个工单的少量行上，扫描成本不变，开销可忽略。
- 上面提到的 `ticket_follow.ticket_id` 缺索引是另一个独立问题，需要加迁移，本 PR 没有一并处理。如果需要我可以另开一个。
- `gofmt` / `go vet` / `go build ./...` 均通过。
