### PR TITLE
fix(subscription): rotate the node credential on admin subscription reset

### DIFF
--- a/internal/module/subscription/internal/usersub/resetusersubscribetoken.go
+++ b/internal/module/subscription/internal/usersub/resetusersubscribetoken.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/perfect-panel/server/internal/model/dto"
 	"github.com/perfect-panel/server/pkg/logger"
 	"github.com/perfect-panel/server/pkg/timeutil"
@@ -34,6 +35,7 @@ func (l *ResetUserSubscribeTokenLogic) ResetUserSubscribeToken(req *dto.ResetUse
 		return errors.Wrapf(xerr.NewErrCode(xerr.DatabaseQueryError), "FindOneSubscribe error: %v", err.Error())
 	}
 	userSub.Token = uuidx.SubscribeToken(fmt.Sprintf("AdminUpdate:%d", timeutil.Now().UnixMilli()))
+	userSub.UUID = uuid.New().String()
 
 	err = l.deps.UserSubs.UpdateSubscribe(l.ctx, userSub)
 	if err != nil {

--- a/internal/module/subscription/internal/usersub/resetusersubscribetoken_test.go
+++ b/internal/module/subscription/internal/usersub/resetusersubscribetoken_test.go
@@ -1,0 +1,76 @@
+package usersub
+
+import (
+	"context"
+	"testing"
+
+	"github.com/perfect-panel/server/internal/model/dto"
+	subEntity "github.com/perfect-panel/server/internal/module/subscription/entity/usersub"
+	"github.com/perfect-panel/server/internal/repository"
+	"gorm.io/gorm"
+)
+
+type resetTokenRepo struct {
+	repository.UserSubscriptionRepo
+	stored  subEntity.Subscribe
+	updated *subEntity.Subscribe
+}
+
+func (r *resetTokenRepo) FindOneSubscribe(_ context.Context, id int64) (*subEntity.Subscribe, error) {
+	sub := r.stored
+	sub.Id = id
+	return &sub, nil
+}
+
+func (r *resetTokenRepo) UpdateSubscribe(_ context.Context, data *subEntity.Subscribe, _ ...*gorm.DB) error {
+	r.updated = data
+	return nil
+}
+
+type resetTokenCache struct {
+	repository.UserCacheRepo
+}
+
+func (resetTokenCache) ClearSubscribeCache(_ context.Context, _ ...*subEntity.Subscribe) error {
+	return nil
+}
+
+type resetTokenPlans struct {
+	repository.SubscribeRepo
+}
+
+func (resetTokenPlans) ClearCache(_ context.Context, _ ...int64) error { return nil }
+
+// Resetting a subscription must rotate the node-side credential as well as the
+// subscription token. Rotating only the token leaves anyone who already pulled
+// the config connecting indefinitely, which defeats the purpose of the reset.
+func TestResetUserSubscribeTokenRotatesTokenAndUUID(t *testing.T) {
+	repo := &resetTokenRepo{
+		stored: subEntity.Subscribe{
+			UserId: 7,
+			Token:  "old-token",
+			UUID:   "old-uuid",
+		},
+	}
+	svc := NewService(Deps{
+		UserSubs: repo,
+		Cache:    resetTokenCache{},
+		Plans:    resetTokenPlans{},
+	})
+
+	if err := svc.ResetUserSubscribeToken(context.Background(), &dto.ResetUserSubscribeTokenRequest{
+		UserSubscribeId: 1,
+	}); err != nil {
+		t.Fatalf("ResetUserSubscribeToken error = %v", err)
+	}
+
+	if repo.updated == nil {
+		t.Fatal("UpdateSubscribe was not called")
+	}
+	if repo.updated.Token == "" || repo.updated.Token == repo.stored.Token {
+		t.Fatalf("Token = %q, want a new non-empty value", repo.updated.Token)
+	}
+	if repo.updated.UUID == "" || repo.updated.UUID == repo.stored.UUID {
+		t.Fatalf("UUID = %q, want a new non-empty value", repo.updated.UUID)
+	}
+}


### PR DESCRIPTION
## 问题

后台对单个用户执行「重置订阅地址」时只轮换了 `Token`，没有轮换 `UUID`。

对比仓库里另外两条重置路径，可以看出这是漏写而不是取舍：

| 路径 | 文件 | `Token` | `UUID` |
|---|---|---|---|
| 用户自助重置 | `internal/module/subscription/internal/selfsub/resetusersubscribetoken.go` | ✅ | ✅ |
| 后台全站批量重置 | `internal/module/subscription/internal/plan/resetallsubscribetoken.go` | ✅ | ✅ |
| **后台单用户重置** | `internal/module/subscription/internal/usersub/resetusersubscribetoken.go` | ✅ | ❌ |

三条里两条都换。如果「后台的重置刻意做得更温和」是设计意图，那么波及面最大的批量重置不可能也换 `UUID`。

## 为什么这是 bug 而不只是不一致

管理员点这个按钮的典型场景，就是某条订阅链接被泄露或被分享、需要切断。但只换 `Token` 拦不住任何**已经拉过配置**的人：`UUID` 是该用户在节点侧的鉴权凭证，经 `internal/module/network/internal/serverapi/getServerUserListLogic.go` 下发给各节点，并在 `internal/module/subscription/internal/delivery/deliver.go` 里作为 Shadowsocks 类协议的 `Password`。凭证没变，对方可以无限期继续连接。

也就是说这个操作在它最主要的用途上是失效的，而且看起来是成功的。

同时，后台目前**没有任何其他办法**轮换单个用户的 `UUID`：

- `usersub/updateusersubscribe.go` 编辑订阅时原样保留 `Token` 和 `UUID`
- `plan/resetallsubscribetoken.go` 会波及全站所有生效订阅
- 删除后重建会丢掉与订单的关联

## 改动

对齐用户自助那条路径，补一行 `userSub.UUID = uuid.New().String()`。

选 `uuid.New()`（v4）而不是本文件已引入的 `uuidx.NewUUID()`（v7），有两个原因：一是与 `selfsub` 和 `usersub/createusersubscribe.go` 保持一致，本 PR 的立意就是让两条重置路径行为相同，不宜引入第三种；二是 v7 内嵌时间戳、随机位少于 v4，作为鉴权凭证 v4 更合适。

缓存清理逻辑本来就在，无需改动。

## 测试

新增 `resetusersubscribetoken_test.go`，断言重置后 `Token` 和 `UUID` 都变成了新的非空值。已验证：把这一行改动撤掉后该测试失败在 `UUID` 断言上。

`gofmt` / `go build ./...` / `go vet` / `go test ./internal/module/subscription/...` 均通过。

## 合并后需要同步的文案

这是一次行为变更：合并后管理员重置某个用户的订阅，会让该用户**所有客户端里已经导入的节点**一并失效，而不只是订阅链接失效。

前端后台现有文案只提到了令牌和链接：

- `resetTokenDescription` = 这将重置订阅地址并重新生成新的令牌。
- `resetSubscriptionTokenDescription` = 将重置订阅令牌，旧订阅链接会失效。

管理员据此会以为影响面仅限于链接。需要的话我可以另开一个前端 PR 同步这两处文案。
