### PR TITLE
fix(marketing): harden quota and email batch tasks

### DIFF
--- a/internal/model/dto/task.go
+++ b/internal/model/dto/task.go
@@ -21,33 +21,33 @@ type BatchSendEmailTask struct {
 }
 
 type CreateBatchSendEmailTaskRequest struct {
-	Subject           string `json:"subject"`
-	Content           string `json:"content"`
-	Scope             int8   `json:"scope"`
-	RegisterStartTime int64  `json:"register_start_time,omitempty"`
-	RegisterEndTime   int64  `json:"register_end_time,omitempty"`
+	Subject           string `json:"subject" validate:"required"`
+	Content           string `json:"content" validate:"required"`
+	Scope             int8   `json:"scope" validate:"required,oneof=1 2 3 4 5"`
+	RegisterStartTime int64  `json:"register_start_time,omitempty" validate:"gte=0"`
+	RegisterEndTime   int64  `json:"register_end_time,omitempty" validate:"gte=0"`
 	Additional        string `json:"additional,omitempty"`
-	Scheduled         int64  `json:"scheduled,omitempty"`
+	Scheduled         int64  `json:"scheduled,omitempty" validate:"gte=0"`
 	Interval          uint8  `json:"interval,omitempty"`
 	Limit             uint64 `json:"limit,omitempty"`
 }
 
 type CreateQuotaTaskRequest struct {
-	Subscribers  []int64 `json:"subscribers"`
+	Subscribers  []int64 `json:"subscribers" validate:"dive,gt=0"`
 	IsActive     *bool   `json:"is_active"`
-	StartTime    int64   `json:"start_time"`
-	EndTime      int64   `json:"end_time"`
+	StartTime    int64   `json:"start_time" validate:"gte=0"`
+	EndTime      int64   `json:"end_time" validate:"gte=0"`
 	ResetTraffic bool    `json:"reset_traffic"`
 	Days         uint64  `json:"days"`
-	GiftType     uint8   `json:"gift_type"`
+	GiftType     uint8   `json:"gift_type" validate:"oneof=0 1 2"`
 	GiftValue    uint64  `json:"gift_value"`
 }
 
 type GetBatchSendEmailTaskListRequest struct {
-	Page   int    `form:"page" validate:"required,gt=0"`
-	Size   int    `form:"size" validate:"required,gt=0,lte=100"`
-	Scope  *int8  `form:"scope,omitempty"`
-	Status *uint8 `form:"status,omitempty"`
+	Page   int    `form:"page" validate:"omitempty,gt=0"`
+	Size   int    `form:"size" validate:"omitempty,gt=0,lte=100"`
+	Scope  *int8  `form:"scope,omitempty" validate:"omitempty,oneof=1 2 3 4 5"`
+	Status *uint8 `form:"status,omitempty" validate:"omitempty,oneof=0 1 2 3 4 5"`
 }
 
 type GetBatchSendEmailTaskListResponse struct {
@@ -56,7 +56,7 @@ type GetBatchSendEmailTaskListResponse struct {
 }
 
 type GetBatchSendEmailTaskStatusRequest struct {
-	Id int64 `json:"id"`
+	Id int64 `json:"id" validate:"required,gt=0"`
 }
 
 type GetBatchSendEmailTaskStatusResponse struct {
@@ -67,9 +67,10 @@ type GetBatchSendEmailTaskStatusResponse struct {
 }
 
 type GetPreSendEmailCountRequest struct {
-	Scope             int8  `json:"scope"`
-	RegisterStartTime int64 `json:"register_start_time,omitempty"`
-	RegisterEndTime   int64 `json:"register_end_time,omitempty"`
+	Scope             int8   `json:"scope" validate:"required,oneof=1 2 3 4 5"`
+	RegisterStartTime int64  `json:"register_start_time,omitempty"`
+	RegisterEndTime   int64  `json:"register_end_time,omitempty"`
+	Additional        string `json:"additional,omitempty"`
 }
 
 type GetPreSendEmailCountResponse struct {
@@ -77,9 +78,9 @@ type GetPreSendEmailCountResponse struct {
 }
 
 type QueryQuotaTaskListRequest struct {
-	Page   int    `form:"page" validate:"required,gt=0"`
-	Size   int    `form:"size" validate:"required,gt=0,lte=100"`
-	Status *uint8 `form:"status,omitempty"`
+	Page   int    `form:"page" validate:"omitempty,gt=0"`
+	Size   int    `form:"size" validate:"omitempty,gt=0,lte=100"`
+	Status *uint8 `form:"status,omitempty" validate:"omitempty,oneof=0 1 2 3 4 5"`
 }
 
 type QueryQuotaTaskListResponse struct {
@@ -90,8 +91,8 @@ type QueryQuotaTaskListResponse struct {
 type QueryQuotaTaskPreCountRequest struct {
 	Subscribers []int64 `json:"subscribers"`
 	IsActive    *bool   `json:"is_active"`
-	StartTime   int64   `json:"start_time"`
-	EndTime     int64   `json:"end_time"`
+	StartTime   int64   `json:"start_time" validate:"gte=0"`
+	EndTime     int64   `json:"end_time" validate:"gte=0"`
 }
 
 type QueryQuotaTaskPreCountResponse struct {
@@ -99,7 +100,7 @@ type QueryQuotaTaskPreCountResponse struct {
 }
 
 type QueryQuotaTaskStatusRequest struct {
-	Id int64 `json:"id"`
+	Id int64 `json:"id" validate:"required,gt=0"`
 }
 
 type QueryQuotaTaskStatusResponse struct {
@@ -129,5 +130,5 @@ type QuotaTask struct {
 }
 
 type StopBatchSendEmailTaskRequest struct {
-	Id int64 `json:"id"`
+	Id int64 `json:"id" validate:"required,gt=0"`
 }

--- a/internal/module/platform/entity/task/task.go
+++ b/internal/module/platform/entity/task/task.go
@@ -13,12 +13,21 @@ const (
 	TypeQuota
 )
 
+const (
+	StatusPending int8 = iota
+	StatusInProgress
+	StatusCompleted
+	StatusFailed
+	StatusCancelled
+	StatusEnqueueFailed
+)
+
 type Task struct {
 	Id        int64     `gorm:"primaryKey;autoIncrement;comment:ID"`
 	Type      int8      `gorm:"not null;comment:Task Type"`
 	Scope     string    `gorm:"type:text;comment:Task Scope"`
 	Content   string    `gorm:"type:text;comment:Task Content"`
-	Status    int8      `gorm:"not null;default:0;comment:Task Status: 0: Pending, 1: In Progress, 2: Completed, 3: Failed"`
+	Status    int8      `gorm:"not null;default:0;comment:Task Status: 0: Pending, 1: In Progress, 2: Completed, 3: Failed, 4: Cancelled, 5: Enqueue Failed"`
 	Errors    string    `gorm:"type:text;comment:Task Errors"`
 	Total     uint64    `gorm:"column:total;not null;default:0;comment:Total Number"`
 	Current   uint64    `gorm:"column:current;not null;default:0;comment:Current Number"`
@@ -62,6 +71,8 @@ type EmailScope struct {
 	Scheduled         int64    `json:"scheduled"`  // scheduled time (unix timestamp)
 	Interval          uint8    `json:"interval"`   // interval in seconds
 	Limit             uint64   `json:"limit"`      // daily send limit
+	DailySent         uint64   `json:"daily_sent,omitempty"`
+	DailyDate         string   `json:"daily_date,omitempty"`
 }
 
 func (s *EmailScope) Marshal() ([]byte, error) {

--- a/internal/module/platform/internal/repo/task.go
+++ b/internal/module/platform/internal/repo/task.go
@@ -2,6 +2,7 @@ package repo
 
 import (
 	"context"
+	"fmt"
 	"github.com/perfect-panel/server/internal/repository"
 
 	"github.com/perfect-panel/server/internal/module/platform/entity/task"
@@ -67,7 +68,7 @@ func (m *taskRepo) QueryTaskList(ctx context.Context, filter *task.Filter) (int6
 		for _, item := range all {
 			var scope task.EmailScope
 			if err := scope.Unmarshal([]byte(item.Scope)); err != nil {
-				continue
+				return 0, nil, fmt.Errorf("decode task %d scope: %w", item.Id, err)
 			}
 			if scope.Type == *filter.Scope {
 				filtered = append(filtered, item)
@@ -98,6 +99,30 @@ func (m *taskRepo) Update(ctx context.Context, data *task.Task) error {
 	return m.db.WithContext(ctx).Where("id = ?", data.Id).Save(data).Error
 }
 
+func (m *taskRepo) UpdateActive(ctx context.Context, data *task.Task) (bool, error) {
+	result := m.db.WithContext(ctx).Model(&task.Task{}).
+		Where("id = ? AND type = ? AND status IN ?", data.Id, data.Type, []int8{task.StatusPending, task.StatusInProgress}).
+		Updates(map[string]interface{}{
+			"scope": data.Scope, "content": data.Content, "status": data.Status,
+			"errors": data.Errors, "total": data.Total, "current": data.Current,
+		})
+	return result.RowsAffected == 1, result.Error
+}
+
 func (m *taskRepo) UpdateStatus(ctx context.Context, id int64, status int8) error {
 	return m.db.WithContext(ctx).Model(&task.Task{}).Where("id = ?", id).Update("status", status).Error
+}
+
+func (m *taskRepo) UpdateStatusFrom(ctx context.Context, id int64, typ task.Type, from []int8, status int8) (bool, error) {
+	result := m.db.WithContext(ctx).Model(&task.Task{}).
+		Where("id = ? AND type = ? AND status IN ?", id, typ, from).
+		Update("status", status)
+	return result.RowsAffected == 1, result.Error
+}
+
+func (m *taskRepo) UpdateStatusAndErrorFrom(ctx context.Context, id int64, typ task.Type, from []int8, status int8, taskError string) (bool, error) {
+	result := m.db.WithContext(ctx).Model(&task.Task{}).
+		Where("id = ? AND type = ? AND status IN ?", id, typ, from).
+		Updates(map[string]interface{}{"status": status, "errors": taskError})
+	return result.RowsAffected == 1, result.Error
 }

--- a/internal/module/platform/internal/repo/task_test.go
+++ b/internal/module/platform/internal/repo/task_test.go
@@ -1,0 +1,61 @@
+package repo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/perfect-panel/server/internal/module/platform/entity/task"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestTaskRepoActiveUpdatesAreTypeAndStateGuarded(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:task-state-guards?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&task.Task{}); err != nil {
+		t.Fatal(err)
+	}
+	repo := NewTaskRepo(db)
+	data := &task.Task{Type: task.TypeEmail, Status: task.StatusPending, Scope: `{}`, Content: `{}`}
+	if err := repo.Insert(context.Background(), data); err != nil {
+		t.Fatal(err)
+	}
+
+	updated, err := repo.UpdateStatusFrom(context.Background(), data.Id, task.TypeQuota, []int8{task.StatusPending}, task.StatusCancelled)
+	if err != nil || updated {
+		t.Fatalf("wrong task type updated: updated=%v err=%v", updated, err)
+	}
+	updated, err = repo.UpdateStatusFrom(context.Background(), data.Id, task.TypeEmail, []int8{task.StatusPending}, task.StatusCancelled)
+	if err != nil || !updated {
+		t.Fatalf("active email task was not cancelled: updated=%v err=%v", updated, err)
+	}
+
+	data.Status = task.StatusCompleted
+	updated, err = repo.UpdateActive(context.Background(), data)
+	if err != nil || updated {
+		t.Fatalf("terminal task accepted stale worker update: updated=%v err=%v", updated, err)
+	}
+	stored, err := repo.FindOneByType(context.Background(), data.Id, task.TypeEmail)
+	if err != nil || stored.Status != task.StatusCancelled {
+		t.Fatalf("cancelled status was overwritten: task=%+v err=%v", stored, err)
+	}
+	updated, err = repo.UpdateStatusAndErrorFrom(context.Background(), data.Id, task.TypeEmail, []int8{task.StatusPending}, task.StatusEnqueueFailed, "redis unavailable")
+	if err != nil || updated {
+		t.Fatalf("terminal task accepted enqueue-failure overwrite: updated=%v err=%v", updated, err)
+	}
+
+	quota := &task.Task{Type: task.TypeQuota, Status: task.StatusPending, Scope: `{}`, Content: `{}`}
+	if err := repo.Insert(context.Background(), quota); err != nil {
+		t.Fatal(err)
+	}
+	updated, err = repo.UpdateStatusAndErrorFrom(context.Background(), quota.Id, task.TypeQuota, []int8{task.StatusPending}, task.StatusEnqueueFailed, "redis unavailable")
+	if err != nil || !updated {
+		t.Fatalf("pending task did not record enqueue failure: updated=%v err=%v", updated, err)
+	}
+	stored, err = repo.FindOneByType(context.Background(), quota.Id, task.TypeQuota)
+	if err != nil || stored.Status != task.StatusEnqueueFailed || stored.Errors != "redis unavailable" {
+		t.Fatalf("enqueue failure was not recorded atomically: task=%+v err=%v", stored, err)
+	}
+}

--- a/internal/module/subscription/internal/quotatask/quotatask.go
+++ b/internal/module/subscription/internal/quotatask/quotatask.go
@@ -13,8 +13,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
+	"math/big"
 	"time"
 
+	"github.com/perfect-panel/server/internal/module/identity/entity/user"
 	"github.com/perfect-panel/server/internal/module/platform/entity/log"
 	"github.com/perfect-panel/server/internal/module/platform/entity/task"
 	"github.com/perfect-panel/server/internal/module/subscription/entity/usersub"
@@ -86,7 +89,8 @@ func (l *QuotaTaskLogic) process(ctx context.Context, taskID int64) error {
 		return err
 	}
 
-	if taskInfo.Status != 0 {
+	if taskInfo.Status == task.StatusCompleted || taskInfo.Status == task.StatusCancelled || taskInfo.Status == task.StatusEnqueueFailed ||
+		(taskInfo.Status == task.StatusFailed && taskInfo.Current >= taskInfo.Total) {
 		logger.WithContext(ctx).Info("[QuotaTaskLogic.ProcessTask] task already processed",
 			logger.Field("taskID", taskID),
 			logger.Field("status", taskInfo.Status),
@@ -96,11 +100,24 @@ func (l *QuotaTaskLogic) process(ctx context.Context, taskID int64) error {
 
 	scope, content, err := l.parseTaskData(ctx, taskInfo)
 	if err != nil {
-		return err
+		return l.failTask(ctx, taskInfo, err)
+	}
+	if err := validateContent(content); err != nil {
+		return l.failTask(ctx, taskInfo, err)
+	}
+	if len(scope.Objects) == 0 {
+		return l.failTask(ctx, taskInfo, fmt.Errorf("quota task has no targets"))
 	}
 
 	subscribes, err := l.getSubscribes(ctx, scope.Objects)
 	if err != nil {
+		return err
+	}
+	if len(subscribes) != len(scope.Objects) {
+		return l.failTask(ctx, taskInfo, fmt.Errorf("quota task target set changed: expected %d subscriptions, found %d", len(scope.Objects), len(subscribes)))
+	}
+	taskInfo.Status = task.StatusInProgress
+	if err := l.updateTask(ctx, taskInfo); err != nil {
 		return err
 	}
 	if err = l.processSubscribes(ctx, subscribes, content, taskInfo); err != nil {
@@ -117,13 +134,13 @@ func (l *QuotaTaskLogic) process(ctx context.Context, taskID int64) error {
 		if err != nil {
 			logger.WithContext(ctx).Error("[QuotaTaskLogic.ProcessTask] find users error",
 				logger.Field("error", err.Error()),
-				logger.Field("userIDs", userIds))
+				logger.Field("user_count", len(userIds)))
 		}
 		err = l.deps.Store.UserCache().ClearUserCache(ctx, users...)
 		if err != nil {
 			logger.WithContext(ctx).Error("[QuotaTaskLogic.ProcessTask] clear user cache error",
 				logger.Field("error", err.Error()),
-				logger.Field("userIDs", userIds))
+				logger.Field("user_count", len(userIds)))
 		}
 	}
 
@@ -138,13 +155,13 @@ func (l *QuotaTaskLogic) process(ctx context.Context, taskID int64) error {
 }
 
 func (l *QuotaTaskLogic) getTaskInfo(ctx context.Context, taskID int64) (*task.Task, error) {
-	taskInfo, err := l.deps.Store.Task().FindOne(ctx, taskID)
+	taskInfo, err := l.deps.Store.Task().FindOneByType(ctx, taskID, task.TypeQuota)
 	if err != nil {
 		logger.WithContext(ctx).Error("[QuotaTaskLogic.getTaskInfo] find task error",
 			logger.Field("error", err.Error()),
 			logger.Field("taskID", taskID),
 		)
-		return nil, ErrUnretryable
+		return nil, err
 	}
 	return taskInfo, nil
 }
@@ -155,7 +172,7 @@ func (l *QuotaTaskLogic) parseTaskData(ctx context.Context, taskInfo *task.Task)
 		logger.WithContext(ctx).Error("[QuotaTaskLogic.parseTaskData] unmarshal scope error",
 			logger.Field("error", err.Error()),
 		)
-		return scope, task.QuotaContent{}, ErrUnretryable
+		return scope, task.QuotaContent{}, fmt.Errorf("%w: parse quota scope: %v", ErrUnretryable, err)
 	}
 
 	var content task.QuotaContent
@@ -163,7 +180,7 @@ func (l *QuotaTaskLogic) parseTaskData(ctx context.Context, taskInfo *task.Task)
 		logger.WithContext(ctx).Error("[QuotaTaskLogic.parseTaskData] unmarshal content error",
 			logger.Field("error", err.Error()),
 		)
-		return scope, content, ErrUnretryable
+		return scope, content, fmt.Errorf("%w: parse quota content: %v", ErrUnretryable, err)
 	}
 	return scope, content, nil
 }
@@ -173,9 +190,9 @@ func (l *QuotaTaskLogic) getSubscribes(ctx context.Context, subscriberIDs []int6
 	if err != nil {
 		logger.WithContext(ctx).Error("[QuotaTaskLogic.getSubscribes] find subscribes error",
 			logger.Field("error", err.Error()),
-			logger.Field("subscribers", subscriberIDs),
+			logger.Field("subscriber_count", len(subscriberIDs)),
 		)
-		return nil, ErrUnretryable
+		return nil, err
 	}
 	return subscribes, nil
 }
@@ -196,7 +213,7 @@ func (l *QuotaTaskLogic) processSubscribes(ctx context.Context, subscribes []*us
 	var errs []ErrorInfo
 	now := timeutil.Now()
 
-	for _, sub := range subscribes {
+	for index, sub := range subscribes {
 		// 验证订阅数据
 		if sub == nil {
 			errs = append(errs, ErrorInfo{
@@ -205,22 +222,40 @@ func (l *QuotaTaskLogic) processSubscribes(ctx context.Context, subscribes []*us
 			})
 			continue
 		}
-		if err := l.grantSubscription(ctx, taskInfo.Id, sub, content, now, &errs); err != nil {
+		if sub.Status == usersub.SubscribeStatusDeducted {
+			errs = append(errs, ErrorInfo{UserSubscribeId: sub.Id, Error: "deducted subscription is not eligible for quota grants"})
+			if err := l.advanceTaskProgress(ctx, taskInfo, uint64(index+1)); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := l.grantSubscription(ctx, taskInfo.Id, sub, content, now); err != nil {
 			return err
 		}
 		if content.GiftValue != 0 {
-			if err := l.grantGift(ctx, taskInfo.Id, sub, content, now, &errs); err != nil {
+			if err := l.grantGift(ctx, taskInfo.Id, sub, content, now); err != nil {
 				return err
 			}
+		}
+		if err := l.advanceTaskProgress(ctx, taskInfo, uint64(index+1)); err != nil {
+			return err
 		}
 	}
 
 	return l.finishTask(ctx, taskInfo, len(subscribes), errs)
 }
 
+func (l *QuotaTaskLogic) advanceTaskProgress(ctx context.Context, taskInfo *task.Task, current uint64) error {
+	if current <= taskInfo.Current {
+		return nil
+	}
+	taskInfo.Current = current
+	return l.updateTask(ctx, taskInfo)
+}
+
 // grantSubscription applies the time extension and traffic reset in a
 // subscription-domain transaction, exactly once per (task, subscription).
-func (l *QuotaTaskLogic) grantSubscription(ctx context.Context, taskID int64, sub *usersub.Subscribe, content task.QuotaContent, now time.Time, errs *[]ErrorInfo) error {
+func (l *QuotaTaskLogic) grantSubscription(ctx context.Context, taskID int64, sub *usersub.Subscribe, content task.QuotaContent, now time.Time) error {
 	return l.deps.Store.InSubscriptionTx(ctx, func(store repository.SubscriptionStore) error {
 		mark, err := store.Inbox().Find(ctx, inboxQuotaGrant, inboxKey(taskID, sub.Id))
 		if err != nil {
@@ -232,43 +267,50 @@ func (l *QuotaTaskLogic) grantSubscription(ctx context.Context, taskID int64, su
 
 		updated := false
 
-		// 处理时间延长 - 修复逻辑：只要Days不为0就处理，不管ExpireTime是否为0
+		// 处理有限期延长，同时保留 NoLimit 的 epoch 哨兵值。
 		if content.Days != 0 {
-			if sub.ExpireTime.Unix() == 0 || sub.ExpireTime.Before(now) {
-				// 如果没有过期时间或已过期，从现在开始计算
+			if sub.ExpireTime.Unix() == 0 {
+				// Unix epoch is the NoLimit sentinel. Adding finite days must
+				// never downgrade an unlimited subscription to a finite term.
+				if sub.Status != usersub.SubscribeStatusActive {
+					sub.Status = usersub.SubscribeStatusActive
+					sub.FinishedAt = nil
+					updated = true
+				}
+			} else if sub.ExpireTime.Before(now) {
+				// 已过期，从现在开始计算
 				sub.ExpireTime = now.AddDate(0, 0, int(content.Days))
+				updated = true
 			} else {
 				// 在原有过期时间基础上延长
 				sub.ExpireTime = sub.ExpireTime.AddDate(0, 0, int(content.Days))
+				updated = true
 			}
 			// 如果订阅延长到未来时间，设置为激活状态
-			if sub.ExpireTime.After(now) && sub.Status != 1 {
-				sub.Status = 1 // Active
+			if sub.ExpireTime.Unix() != 0 && sub.ExpireTime.After(now) && sub.Status != usersub.SubscribeStatusActive {
+				sub.Status = usersub.SubscribeStatusActive
+				sub.FinishedAt = nil
 			}
-			updated = true
 		}
 
 		// 处理流量重置
 		if content.ResetTraffic {
 			sub.Download = 0
 			sub.Upload = 0
+			if sub.Status == usersub.SubscribeStatusFinished {
+				sub.Status = usersub.SubscribeStatusActive
+				sub.FinishedAt = nil
+			}
 			updated = true
 			if err := l.createResetTrafficLog(ctx, store.Log(), sub.Id, sub.UserId, now); err != nil {
-				// 记录错误但不阻断整个任务,日志失败不影响主流程
-				*errs = append(*errs, ErrorInfo{
-					UserSubscribeId: sub.Id,
-					Error:           "create reset traffic log error: " + err.Error(),
-				})
+				return fmt.Errorf("create reset traffic log for subscription %d: %w", sub.Id, err)
 			}
 		}
 
 		// 只有在有更新时才保存订阅信息
 		if updated {
 			if err := store.UserSubscription().UpdateSubscribe(ctx, sub); err != nil {
-				*errs = append(*errs, ErrorInfo{
-					UserSubscribeId: sub.Id,
-					Error:           "update subscription error: " + err.Error(),
-				})
+				return fmt.Errorf("update subscription %d: %w", sub.Id, err)
 			}
 		}
 
@@ -282,13 +324,14 @@ func (l *QuotaTaskLogic) grantSubscription(ctx context.Context, taskID int64, su
 // once per (task, subscription). The plan lookup for the percentage gift is
 // a cross-domain read done before the transaction — reference data, not
 // billing state.
-func (l *QuotaTaskLogic) grantGift(ctx context.Context, taskID int64, sub *usersub.Subscribe, content task.QuotaContent, now time.Time, errs *[]ErrorInfo) error {
-	// 验证赠送类型
-	if content.GiftType != 1 && content.GiftType != 2 {
-		*errs = append(*errs, ErrorInfo{
-			UserSubscribeId: sub.Id,
-			Error:           fmt.Sprintf("invalid gift type: %d", content.GiftType),
-		})
+func (l *QuotaTaskLogic) grantGift(ctx context.Context, taskID int64, sub *usersub.Subscribe, content task.QuotaContent, now time.Time) error {
+	key := inboxKey(taskID, sub.Id)
+	mark, err := l.deps.Store.Inbox().Find(ctx, inboxQuotaGift, key)
+	if err != nil {
+		return err
+	}
+	if mark != nil {
+		l.clearGiftUserCache(ctx, sub.UserId)
 		return nil
 	}
 
@@ -300,19 +343,20 @@ func (l *QuotaTaskLogic) grantGift(ctx context.Context, taskID int64, sub *users
 		// 获取订阅对应的套餐信息
 		subscribeInfo, err := l.deps.Store.Subscribe().FindOne(ctx, sub.SubscribeId)
 		if err != nil {
-			*errs = append(*errs, ErrorInfo{
-				UserSubscribeId: sub.Id,
-				Error:           "find subscribe error: " + err.Error(),
-			})
-			return nil
+			return fmt.Errorf("find plan for subscription %d: %w", sub.Id, err)
 		}
 		if subscribeInfo.UnitPrice > 0 {
-			giftAmount = int64(float64(subscribeInfo.UnitPrice) * (float64(content.GiftValue) / 100))
+			amount := new(big.Int).Mul(big.NewInt(subscribeInfo.UnitPrice), new(big.Int).SetUint64(content.GiftValue))
+			amount.Div(amount, big.NewInt(100))
+			if !amount.IsInt64() {
+				return fmt.Errorf("calculated gift amount overflows int64 for subscription %d", sub.Id)
+			}
+			giftAmount = amount.Int64()
 		}
 	}
 
-	return l.deps.Store.InBillingTx(ctx, func(store repository.BillingStore) error {
-		mark, err := store.Inbox().Find(ctx, inboxQuotaGift, inboxKey(taskID, sub.Id))
+	err = l.deps.Store.InBillingTx(ctx, func(store repository.BillingStore) error {
+		mark, err := store.Inbox().Find(ctx, inboxQuotaGift, key)
 		if err != nil {
 			return err
 		}
@@ -323,11 +367,10 @@ func (l *QuotaTaskLogic) grantGift(ctx context.Context, taskID int64, sub *users
 		if giftAmount > 0 {
 			wallet, err := store.Wallet().FindOneForUpdate(ctx, sub.UserId)
 			if err != nil {
-				*errs = append(*errs, ErrorInfo{
-					UserSubscribeId: sub.Id,
-					Error:           "find user error: " + err.Error(),
-				})
-				return nil
+				return fmt.Errorf("find wallet for user %d: %w", sub.UserId, err)
+			}
+			if giftAmount > 0 && wallet.GiftAmount > math.MaxInt64-giftAmount {
+				return fmt.Errorf("gift balance overflows for user %d", sub.UserId)
 			}
 			wallet.GiftAmount += giftAmount
 			if err := store.Wallet().UpdateBalanceFields(ctx, wallet); err != nil {
@@ -338,24 +381,46 @@ func (l *QuotaTaskLogic) grantGift(ctx context.Context, taskID int64, sub *users
 			}
 		}
 
-		return store.Inbox().Insert(ctx, inboxQuotaGift, inboxKey(taskID, sub.Id), "")
+		return store.Inbox().Insert(ctx, inboxQuotaGift, key, "")
 	})
+	if err != nil {
+		return err
+	}
+	if giftAmount > 0 {
+		// The gift transaction may commit before a later subscription fails.
+		// Clear this user's balance projection immediately so a partial task
+		// never leaves committed money hidden behind stale cache state.
+		l.clearGiftUserCache(ctx, sub.UserId)
+	}
+	return nil
+}
+
+func (l *QuotaTaskLogic) clearGiftUserCache(ctx context.Context, userID int64) {
+	if err := l.deps.Store.UserCache().ClearUserCache(ctx, &user.User{Id: userID}); err != nil {
+		logger.WithContext(ctx).Error("[QuotaTaskLogic.grantGift] clear user cache error",
+			logger.Field("error", err.Error()))
+	}
 }
 
 // finishTask records the outcome on the task row in a platform-domain
-// transaction. The task stays pending (status 0) if an earlier stage
-// hard-failed, so the retry path is the status check in process().
+// transaction. The task stays in progress if an earlier stage hard-failed,
+// so the queue retry resumes through the inbox markers.
 func (l *QuotaTaskLogic) finishTask(ctx context.Context, taskInfo *task.Task, total int, errs []ErrorInfo) error {
 	// 根据错误情况决定任务状态
-	status := int8(2) // Completed
+	status := task.StatusCompleted
+	taskInfo.Errors = ""
 	if len(errs) > 0 {
 		logger.WithContext(ctx).Error("[QuotaTaskLogic.processSubscribes] some subscriptions failed",
 			logger.Field("total", total),
 			logger.Field("failed", len(errs)),
 		)
 		// 如果所有订阅都失败，标记为失败状态
-		if len(errs) == total {
-			status = 3 // Failed
+		failedSubscriptions := make(map[int64]struct{}, len(errs))
+		for _, item := range errs {
+			failedSubscriptions[item.UserSubscribeId] = struct{}{}
+		}
+		if len(failedSubscriptions) >= total {
+			status = task.StatusFailed
 		}
 		marshaled, err := json.Marshal(errs)
 		if err != nil {
@@ -369,6 +434,10 @@ func (l *QuotaTaskLogic) finishTask(ctx context.Context, taskInfo *task.Task, to
 
 	taskInfo.Current = uint64(total)
 	taskInfo.Status = status
+	return l.updateTask(ctx, taskInfo)
+}
+
+func (l *QuotaTaskLogic) updateTask(ctx context.Context, taskInfo *task.Task) error {
 	return l.deps.Store.InPlatformTx(ctx, func(store repository.PlatformStore) error {
 		if err := store.Task().Update(ctx, taskInfo); err != nil {
 			logger.WithContext(ctx).Error("[QuotaTaskLogic.processSubscribes] update task status error",
@@ -379,6 +448,34 @@ func (l *QuotaTaskLogic) finishTask(ctx context.Context, taskInfo *task.Task, to
 		}
 		return nil
 	})
+}
+
+func (l *QuotaTaskLogic) failTask(ctx context.Context, taskInfo *task.Task, cause error) error {
+	taskInfo.Status = task.StatusFailed
+	taskInfo.Errors = cause.Error()
+	return l.updateTask(ctx, taskInfo)
+}
+
+func validateContent(content task.QuotaContent) error {
+	if !content.ResetTraffic && content.Days == 0 && content.GiftValue == 0 {
+		return fmt.Errorf("quota task has no action")
+	}
+	if content.Days > uint64(^uint(0)>>1) {
+		return fmt.Errorf("quota task days overflow")
+	}
+	if content.GiftValue == 0 {
+		if content.GiftType != 0 {
+			return fmt.Errorf("quota task gift type has no value")
+		}
+		return nil
+	}
+	if content.GiftType != 1 && content.GiftType != 2 {
+		return fmt.Errorf("invalid quota task gift type: %d", content.GiftType)
+	}
+	if content.GiftValue > math.MaxInt64 {
+		return fmt.Errorf("quota task gift value overflow")
+	}
+	return nil
 }
 
 func (l *QuotaTaskLogic) getStartTime(sub *usersub.Subscribe, now time.Time) time.Time {

--- a/internal/module/subscription/internal/quotatask/quotatask_test.go
+++ b/internal/module/subscription/internal/quotatask/quotatask_test.go
@@ -1,0 +1,167 @@
+package quotatask
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	userEntity "github.com/perfect-panel/server/internal/module/identity/entity/user"
+	"github.com/perfect-panel/server/internal/module/platform/entity/inbox"
+	logEntity "github.com/perfect-panel/server/internal/module/platform/entity/log"
+	"github.com/perfect-panel/server/internal/module/platform/entity/task"
+	"github.com/perfect-panel/server/internal/module/subscription/entity/usersub"
+	"github.com/perfect-panel/server/internal/repository"
+	"gorm.io/gorm"
+)
+
+type quotaFailureStore struct {
+	repository.Store
+	subscription repository.SubscriptionStore
+}
+
+func (s *quotaFailureStore) InSubscriptionTx(_ context.Context, fn func(repository.SubscriptionStore) error) error {
+	return fn(s.subscription)
+}
+
+type quotaSubscriptionStore struct {
+	repository.SubscriptionStore
+	users repository.UserSubscriptionRepo
+	inbox repository.InboxRepo
+}
+
+func (s *quotaSubscriptionStore) UserSubscription() repository.UserSubscriptionRepo { return s.users }
+func (s *quotaSubscriptionStore) Inbox() repository.InboxRepo                       { return s.inbox }
+func (s *quotaSubscriptionStore) Log() repository.LogRepo                           { return quotaLogRepo{} }
+
+type quotaLogRepo struct{ repository.LogRepo }
+
+func (quotaLogRepo) Insert(context.Context, *logEntity.SystemLog) error { return nil }
+
+type failingSubscriptionRepo struct {
+	repository.UserSubscriptionRepo
+	err error
+}
+
+func (r *failingSubscriptionRepo) UpdateSubscribe(_ context.Context, _ *usersub.Subscribe, _ ...*gorm.DB) error {
+	return r.err
+}
+
+type quotaInbox struct {
+	repository.InboxRepo
+	inserts int
+}
+
+type quotaGiftReplayStore struct {
+	repository.Store
+	inbox        repository.InboxRepo
+	cache        repository.UserCacheRepo
+	billingCalls int
+}
+
+func (s *quotaGiftReplayStore) Inbox() repository.InboxRepo         { return s.inbox }
+func (s *quotaGiftReplayStore) UserCache() repository.UserCacheRepo { return s.cache }
+func (s *quotaGiftReplayStore) InBillingTx(_ context.Context, _ func(repository.BillingStore) error) error {
+	s.billingCalls++
+	return errors.New("billing transaction should not run for a completed gift stage")
+}
+
+type existingQuotaInbox struct{ repository.InboxRepo }
+
+func (existingQuotaInbox) Find(context.Context, string, string) (*inbox.Record, error) {
+	return &inbox.Record{Consumer: inboxQuotaGift, EventKey: "7:9"}, nil
+}
+
+type recordingUserCache struct {
+	repository.UserCacheRepo
+	cleared int
+}
+
+func (c *recordingUserCache) ClearUserCache(_ context.Context, users ...*userEntity.User) error {
+	c.cleared += len(users)
+	return nil
+}
+
+func (r *quotaInbox) Find(context.Context, string, string) (*inbox.Record, error) { return nil, nil }
+func (r *quotaInbox) Insert(context.Context, string, string, string) error {
+	r.inserts++
+	return nil
+}
+
+func TestGrantSubscriptionDoesNotMarkInboxAfterUpdateFailure(t *testing.T) {
+	wantErr := errors.New("write failed")
+	users := &failingSubscriptionRepo{err: wantErr}
+	marks := &quotaInbox{}
+	store := &quotaFailureStore{subscription: &quotaSubscriptionStore{users: users, inbox: marks}}
+	logic := &QuotaTaskLogic{deps: Deps{Store: store}}
+	sub := &usersub.Subscribe{Id: 9, ExpireTime: time.Now().Add(time.Hour)}
+
+	err := logic.grantSubscription(context.Background(), 7, sub, task.QuotaContent{Days: 1}, time.Now())
+	if err == nil || marks.inserts != 0 {
+		t.Fatalf("update error must roll back without an inbox marker: err=%v inserts=%d", err, marks.inserts)
+	}
+}
+
+func TestGrantSubscriptionReactivatesTrafficFinishedSubscription(t *testing.T) {
+	users := &failingSubscriptionRepo{}
+	marks := &quotaInbox{}
+	store := &quotaFailureStore{subscription: &quotaSubscriptionStore{users: users, inbox: marks}}
+	logic := &QuotaTaskLogic{deps: Deps{Store: store}}
+	finishedAt := time.Now()
+	sub := &usersub.Subscribe{
+		Id: 9, Status: usersub.SubscribeStatusFinished, FinishedAt: &finishedAt,
+		Download: 10, Upload: 20,
+	}
+
+	if err := logic.grantSubscription(context.Background(), 7, sub, task.QuotaContent{ResetTraffic: true}, time.Now()); err != nil {
+		t.Fatalf("grantSubscription: %v", err)
+	}
+	if sub.Status != usersub.SubscribeStatusActive || sub.FinishedAt != nil || sub.Download != 0 || sub.Upload != 0 || marks.inserts != 1 {
+		t.Fatalf("reset quota did not reactivate subscription atomically: sub=%+v inserts=%d", sub, marks.inserts)
+	}
+}
+
+func TestGrantSubscriptionPreservesNoLimitExpiry(t *testing.T) {
+	users := &failingSubscriptionRepo{}
+	marks := &quotaInbox{}
+	store := &quotaFailureStore{subscription: &quotaSubscriptionStore{users: users, inbox: marks}}
+	logic := &QuotaTaskLogic{deps: Deps{Store: store}}
+	sub := &usersub.Subscribe{Id: 9, Status: usersub.SubscribeStatusActive, ExpireTime: time.UnixMilli(0)}
+
+	if err := logic.grantSubscription(context.Background(), 7, sub, task.QuotaContent{Days: 30}, time.Now()); err != nil {
+		t.Fatalf("grantSubscription: %v", err)
+	}
+	if sub.ExpireTime.UnixMilli() != 0 || sub.Status != usersub.SubscribeStatusActive || marks.inserts != 1 {
+		t.Fatalf("NoLimit subscription was downgraded: sub=%+v inserts=%d", sub, marks.inserts)
+	}
+}
+
+func TestGrantGiftReplaySkipsPlanLookupAndRefreshesCache(t *testing.T) {
+	cache := &recordingUserCache{}
+	store := &quotaGiftReplayStore{inbox: existingQuotaInbox{}, cache: cache}
+	logic := &QuotaTaskLogic{deps: Deps{Store: store}}
+
+	err := logic.grantGift(context.Background(), 7, &usersub.Subscribe{Id: 9, UserId: 11, SubscribeId: 13}, task.QuotaContent{GiftType: 2, GiftValue: 10}, time.Now())
+	if err != nil {
+		t.Fatalf("completed gift replay: %v", err)
+	}
+	if store.billingCalls != 0 || cache.cleared != 1 {
+		t.Fatalf("completed gift stage replayed work: billing_calls=%d cache_clears=%d", store.billingCalls, cache.cleared)
+	}
+}
+
+func TestValidateContentRejectsInvalidQuotaActions(t *testing.T) {
+	for _, content := range []task.QuotaContent{
+		{},
+		{GiftType: 1},
+		{GiftType: 9, GiftValue: 1},
+		{GiftType: 1, GiftValue: ^uint64(0)},
+	} {
+		if err := validateContent(content); err == nil {
+			t.Fatalf("invalid content accepted: %+v", content)
+		}
+	}
+	if err := validateContent(task.QuotaContent{Days: 1}); err != nil {
+		t.Fatalf("valid quota action rejected: %v", err)
+	}
+}

--- a/internal/module/subscription/internal/repo/marketing_filter_test.go
+++ b/internal/module/subscription/internal/repo/marketing_filter_test.go
@@ -1,0 +1,38 @@
+package repo
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/perfect-panel/server/internal/module/subscription/entity/usersub"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+func TestSubscribeFilterHonorsBothActiveValues(t *testing.T) {
+	db, err := gorm.Open(mysql.New(mysql.Config{
+		DSN:                       "gorm:gorm@tcp(localhost:9910)/gorm?charset=utf8&parseTime=True&loc=Local",
+		SkipInitializeWithVersion: true,
+	}), &gorm.Config{DryRun: true, DisableAutomaticPing: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	active := true
+	var rows []*usersub.Subscribe
+	activeStmt := subscribeFilterQuery(db, &usersub.SubscribeFilter{IsActive: &active}).Find(&rows).Statement
+	if !strings.Contains(activeStmt.SQL.String(), "status IN (?,?,?)") {
+		t.Fatalf("active filter = SQL %s vars %#v", activeStmt.SQL.String(), activeStmt.Vars)
+	}
+
+	inactive := false
+	inactiveStmt := subscribeFilterQuery(db, &usersub.SubscribeFilter{IsActive: &inactive}).Find(&rows).Statement
+	if !strings.Contains(inactiveStmt.SQL.String(), "status IN (?,?)") {
+		t.Fatalf("inactive filter = SQL %s vars %#v", inactiveStmt.SQL.String(), inactiveStmt.Vars)
+	}
+
+	unfilteredSQL := subscribeFilterQuery(db, &usersub.SubscribeFilter{}).Find(&rows).Statement.SQL.String()
+	if !strings.Contains(unfilteredSQL, "status <> ?") {
+		t.Fatalf("unfiltered quota scope must exclude deducted subscriptions: %s", unfilteredSQL)
+	}
+}

--- a/internal/module/subscription/internal/repo/user_subscription.go
+++ b/internal/module/subscription/internal/repo/user_subscription.go
@@ -691,8 +691,23 @@ func subscribeFilterQuery(conn *gorm.DB, filter *usersub.SubscribeFilter) *gorm.
 	if len(filter.Subscribers) > 0 {
 		query = query.Where("subscribe_id IN ?", filter.Subscribers)
 	}
-	if filter.IsActive != nil && *filter.IsActive {
-		query = query.Where("status IN ?", []int64{0, 1, 2})
+	if filter.IsActive != nil {
+		if *filter.IsActive {
+			query = query.Where("status IN ?", []int64{
+				int64(usersub.SubscribeStatusPending),
+				int64(usersub.SubscribeStatusActive),
+				int64(usersub.SubscribeStatusFinished),
+			})
+		} else {
+			query = query.Where("status IN ?", []int64{
+				int64(usersub.SubscribeStatusExpired),
+				int64(usersub.SubscribeStatusStopped),
+			})
+		}
+	} else {
+		// Deducted subscriptions were refunded/cancelled and must never receive
+		// marketing quota grants, even when no activity filter was supplied.
+		query = query.Where("status <> ?", usersub.SubscribeStatusDeducted)
 	}
 	if filter.StartTime != 0 {
 		query = query.Where("start_time <= ?", time.UnixMilli(filter.StartTime))

--- a/internal/module/support/internal/marketing/service.go
+++ b/internal/module/support/internal/marketing/service.go
@@ -5,6 +5,9 @@ package marketing
 
 import (
 	"context"
+	"fmt"
+	"math"
+	"net/mail"
 	"strings"
 	"time"
 
@@ -61,6 +64,9 @@ func NewService(tasks repository.TaskRepo, recipients EmailRecipientReader, sele
 }
 
 func (s *Service) CreateBatchSendEmailTask(ctx context.Context, req *dto.CreateBatchSendEmailTaskRequest) error {
+	if err := validateBatchEmailRequest(req); err != nil {
+		return err
+	}
 	log := logger.WithContext(ctx)
 	scope := task.ParseScopeType(req.Scope)
 	emails, err := s.recipients.QueryEmailRecipients(ctx, &user.EmailRecipientFilter{
@@ -73,23 +79,20 @@ func (s *Service) CreateBatchSendEmailTask(ctx context.Context, req *dto.CreateB
 		return xerr.NewErrCode(xerr.DatabaseQueryError)
 	}
 
-	// 邮箱列表为空，返回错误
-	if len(emails) == 0 && scope != task.ScopeSkip {
-		log.Errorf("[CreateBatchSendEmailTask] No email addresses found for the specified scope")
-		return xerr.NewErrMsg("No email addresses found for the specified scope")
-	}
-
 	// 邮箱地址去重
 	emails = tool.RemoveDuplicateElements(emails...)
 
 	var additionalEmails []string
 	// 追加额外的邮箱地址（不覆盖）
 	if req.Additional != "" {
-		additionalEmails = tool.RemoveDuplicateElements(strings.Split(req.Additional, "\n")...)
+		additionalEmails, err = normalizeAdditionalEmails(req.Additional)
+		if err != nil {
+			return xerr.NewErrMsg(err.Error())
+		}
 	}
-	if len(additionalEmails) == 0 && scope == task.ScopeSkip {
-		log.Errorf("[CreateBatchSendEmailTask] No additional email addresses provided for skip scope")
-		return xerr.NewErrMsg("No additional email addresses provided for skip scope")
+	if len(tool.RemoveDuplicateElements(append(emails, additionalEmails...)...)) == 0 {
+		log.Errorf("[CreateBatchSendEmailTask] No email addresses provided for campaign")
+		return xerr.NewErrMsg("No email addresses found for the campaign")
 	}
 
 	scheduledAt := timeutil.Now().Add(10 * time.Second) // 默认延迟10秒执行,防止任务创建和执行时间过于接近
@@ -106,17 +109,23 @@ func (s *Service) CreateBatchSendEmailTask(ctx context.Context, req *dto.CreateB
 		RegisterEndTime:   req.RegisterEndTime,
 		Recipients:        emails,
 		Additional:        additionalEmails,
-		Scheduled:         req.Scheduled,
+		Scheduled:         scheduledAt.Unix(),
 		Interval:          req.Interval,
 		Limit:             req.Limit,
 	}
-	scopeBytes, _ := scopeInfo.Marshal()
+	scopeBytes, err := scopeInfo.Marshal()
+	if err != nil {
+		return errors.Wrap(err, "marshal email task scope")
+	}
 
 	taskContent := task.EmailContent{
 		Subject: req.Subject,
 		Content: req.Content,
 	}
-	contentBytes, _ := taskContent.Marshal()
+	contentBytes, err := taskContent.Marshal()
+	if err != nil {
+		return errors.Wrap(err, "marshal email task content")
+	}
 
 	var total uint64
 	if additionalEmails != nil {
@@ -130,7 +139,7 @@ func (s *Service) CreateBatchSendEmailTask(ctx context.Context, req *dto.CreateB
 		Type:    task.TypeEmail,
 		Scope:   string(scopeBytes),
 		Content: string(contentBytes),
-		Status:  0,
+		Status:  task.StatusPending,
 		Errors:  "",
 		Total:   total,
 		Current: 0,
@@ -145,6 +154,7 @@ func (s *Service) CreateBatchSendEmailTask(ctx context.Context, req *dto.CreateB
 	queueTaskID, err := s.queue.EnqueueBatchEmail(ctx, taskInfo.Id, scheduledAt)
 	if err != nil {
 		log.Errorf("[CreateBatchSendEmailTask] Failed to enqueue email task: %v", err.Error())
+		s.markTaskEnqueueFailed(ctx, taskInfo, fmt.Sprintf("enqueue email task: %v", err))
 		return xerr.NewErrCode(xerr.QueueEnqueueError)
 	}
 	log.Infof("[CreateBatchSendEmailTask] Successfully enqueued email task with ID: %s, scheduled at: %s", queueTaskID, scheduledAt.Format(time.DateTime))
@@ -153,8 +163,17 @@ func (s *Service) CreateBatchSendEmailTask(ctx context.Context, req *dto.CreateB
 }
 
 func (s *Service) GetPreSendEmailCount(ctx context.Context, req *dto.GetPreSendEmailCountRequest) (*dto.GetPreSendEmailCountResponse, error) {
+	if req == nil || req.Scope < task.ScopeAll.Int8() || req.Scope > task.ScopeSkip.Int8() {
+		return nil, xerr.NewErrMsg("invalid email scope")
+	}
+	if req.RegisterStartTime != 0 && req.RegisterEndTime != 0 && req.RegisterStartTime > req.RegisterEndTime {
+		return nil, xerr.NewErrMsg("register_start_time must not be after register_end_time")
+	}
+	if req.RegisterStartTime < 0 || req.RegisterEndTime < 0 {
+		return nil, xerr.NewErrMsg("registration timestamps must not be negative")
+	}
 	scope := task.ParseScopeType(req.Scope)
-	count, err := s.recipients.CountEmailRecipients(ctx, &user.EmailRecipientFilter{
+	emails, err := s.recipients.QueryEmailRecipients(ctx, &user.EmailRecipientFilter{
 		Scope:             scope.Int8(),
 		RegisterStartTime: req.RegisterStartTime,
 		RegisterEndTime:   req.RegisterEndTime,
@@ -163,11 +182,19 @@ func (s *Service) GetPreSendEmailCount(ctx context.Context, req *dto.GetPreSendE
 		logger.WithContext(ctx).Errorf("[GetPreSendEmailCount] Count error: %v", err)
 		return nil, xerr.NewErrMsg("Failed to count emails")
 	}
-	return &dto.GetPreSendEmailCountResponse{Count: count}, nil
+	additional, err := normalizeAdditionalEmails(req.Additional)
+	if err != nil {
+		return nil, xerr.NewErrMsg(err.Error())
+	}
+	count := len(tool.RemoveDuplicateElements(append(emails, additional...)...))
+	return &dto.GetPreSendEmailCountResponse{Count: int64(count)}, nil
 }
 
 func (s *Service) GetBatchSendEmailTaskList(ctx context.Context, req *dto.GetBatchSendEmailTaskListRequest) (*dto.GetBatchSendEmailTaskListResponse, error) {
 	log := logger.WithContext(ctx)
+	if req == nil {
+		req = &dto.GetBatchSendEmailTaskListRequest{}
+	}
 	if req.Page == 0 {
 		req.Page = 1
 	}
@@ -191,12 +218,12 @@ func (s *Service) GetBatchSendEmailTaskList(ctx context.Context, req *dto.GetBat
 		var scopeInfo task.EmailScope
 		if err = scopeInfo.Unmarshal([]byte(t.Scope)); err != nil {
 			log.Errorf("[GetBatchSendEmailTaskList] failed to unmarshal email task scope: %v", err.Error())
-			continue
+			return nil, xerr.NewErrCode(xerr.DatabaseQueryError)
 		}
 		var contentInfo task.EmailContent
 		if err = contentInfo.Unmarshal([]byte(t.Content)); err != nil {
 			log.Errorf("[GetBatchSendEmailTaskList] failed to unmarshal email task content: %v", err.Error())
-			continue
+			return nil, xerr.NewErrCode(xerr.DatabaseQueryError)
 		}
 
 		list = append(list, dto.BatchSendEmailTask{
@@ -224,7 +251,10 @@ func (s *Service) GetBatchSendEmailTaskList(ctx context.Context, req *dto.GetBat
 }
 
 func (s *Service) GetBatchSendEmailTaskStatus(ctx context.Context, req *dto.GetBatchSendEmailTaskStatusRequest) (*dto.GetBatchSendEmailTaskStatusResponse, error) {
-	taskInfo, err := s.tasks.FindOne(ctx, req.Id)
+	if req == nil || req.Id <= 0 {
+		return nil, xerr.NewErrMsg("invalid task id")
+	}
+	taskInfo, err := s.tasks.FindOneByType(ctx, req.Id, task.TypeEmail)
 	if err != nil {
 		logger.WithContext(ctx).Errorf("failed to get email task status, error: %v", err)
 		return nil, xerr.NewErrCode(xerr.DatabaseQueryError)
@@ -238,19 +268,29 @@ func (s *Service) GetBatchSendEmailTaskStatus(ctx context.Context, req *dto.GetB
 }
 
 func (s *Service) StopBatchSendEmailTask(ctx context.Context, req *dto.StopBatchSendEmailTaskRequest) error {
+	if req == nil || req.Id <= 0 {
+		return xerr.NewErrMsg("invalid task id")
+	}
+	updated, err := s.tasks.UpdateStatusFrom(ctx, req.Id, task.TypeEmail, []int8{task.StatusPending, task.StatusInProgress}, task.StatusCancelled)
+	if err != nil {
+		logger.WithContext(ctx).Errorf("failed to stop email task, error: %v", err)
+		return xerr.NewErrCode(xerr.DatabaseUpdateError)
+	}
+	if !updated {
+		return xerr.NewErrMsg("email task is not stoppable")
+	}
 	if s.stopper != nil {
 		s.stopper.StopBatchEmail(req.Id)
 	} else {
 		logger.Error("[StopBatchSendEmailTaskLogic] email worker manager is nil, cannot stop task")
 	}
-	if err := s.tasks.UpdateStatus(ctx, req.Id, 2); err != nil {
-		logger.WithContext(ctx).Errorf("failed to stop email task, error: %v", err)
-		return xerr.NewErrCode(xerr.DatabaseUpdateError)
-	}
 	return nil
 }
 
 func (s *Service) CreateQuotaTask(ctx context.Context, req *dto.CreateQuotaTaskRequest) error {
+	if err := validateQuotaRequest(req); err != nil {
+		return err
+	}
 	log := logger.WithContext(ctx)
 	subIds, err := s.selector.QuerySubscribeIdsByFilter(ctx, &usersub.SubscribeFilter{
 		Subscribers: req.Subscribers,
@@ -273,18 +313,24 @@ func (s *Service) CreateQuotaTask(ctx context.Context, req *dto.CreateQuotaTaskR
 		EndTime:     req.EndTime,
 		Objects:     subIds,
 	}
-	scopeBytes, _ := scopeInfo.Marshal()
+	scopeBytes, err := scopeInfo.Marshal()
+	if err != nil {
+		return errors.Wrap(err, "marshal quota task scope")
+	}
 	contentInfo := task.QuotaContent{
 		ResetTraffic: req.ResetTraffic,
 		Days:         req.Days,
 		GiftType:     req.GiftType,
 		GiftValue:    req.GiftValue,
 	}
-	contentBytes, _ := contentInfo.Marshal()
+	contentBytes, err := contentInfo.Marshal()
+	if err != nil {
+		return errors.Wrap(err, "marshal quota task content")
+	}
 
 	newTask := &task.Task{
 		Type:    task.TypeQuota,
-		Status:  0,
+		Status:  task.StatusPending,
 		Scope:   string(scopeBytes),
 		Content: string(contentBytes),
 		Total:   uint64(len(subIds)),
@@ -299,6 +345,7 @@ func (s *Service) CreateQuotaTask(ctx context.Context, req *dto.CreateQuotaTaskR
 
 	if err := s.queue.EnqueueQuota(ctx, newTask.Id); err != nil {
 		log.Errorf("[CreateQuotaTask] enqueue task error: %v", err.Error())
+		s.markTaskEnqueueFailed(ctx, newTask, fmt.Sprintf("enqueue quota task: %v", err))
 		return errors.Wrapf(xerr.NewErrCode(xerr.QueueEnqueueError), "enqueue task error")
 	}
 	logger.Infof("[CreateQuotaTask] Successfully created task with ID: %d", newTask.Id)
@@ -307,6 +354,9 @@ func (s *Service) CreateQuotaTask(ctx context.Context, req *dto.CreateQuotaTaskR
 
 func (s *Service) QueryQuotaTaskList(ctx context.Context, req *dto.QueryQuotaTaskListRequest) (*dto.QueryQuotaTaskListResponse, error) {
 	log := logger.WithContext(ctx)
+	if req == nil {
+		req = &dto.QueryQuotaTaskListRequest{}
+	}
 	if req.Page == 0 {
 		req.Page = 1
 	}
@@ -322,7 +372,7 @@ func (s *Service) QueryQuotaTaskList(ctx context.Context, req *dto.QueryQuotaTas
 	})
 	if err != nil {
 		log.Errorf("[QueryQuotaTaskList] failed to get quota tasks: %v", err)
-		return nil, err
+		return nil, xerr.NewErrCode(xerr.DatabaseQueryError)
 	}
 
 	var list []dto.QuotaTask
@@ -330,12 +380,12 @@ func (s *Service) QueryQuotaTaskList(ctx context.Context, req *dto.QueryQuotaTas
 		var scopeInfo task.QuotaScope
 		if err = scopeInfo.Unmarshal([]byte(item.Scope)); err != nil {
 			log.Errorf("[QueryQuotaTaskList] failed to unmarshal quota task scope: %v", err.Error())
-			continue
+			return nil, xerr.NewErrCode(xerr.DatabaseQueryError)
 		}
 		var contentInfo task.QuotaContent
 		if err = contentInfo.Unmarshal([]byte(item.Content)); err != nil {
 			log.Errorf("[QueryQuotaTaskList] failed to unmarshal quota task content: %v", err.Error())
-			continue
+			return nil, xerr.NewErrCode(xerr.DatabaseQueryError)
 		}
 		list = append(list, dto.QuotaTask{
 			Id:           item.Id,
@@ -361,6 +411,15 @@ func (s *Service) QueryQuotaTaskList(ctx context.Context, req *dto.QueryQuotaTas
 }
 
 func (s *Service) QueryQuotaTaskPreCount(ctx context.Context, req *dto.QueryQuotaTaskPreCountRequest) (*dto.QueryQuotaTaskPreCountResponse, error) {
+	if req == nil {
+		return nil, xerr.NewErrMsg("request is required")
+	}
+	if req.StartTime != 0 && req.EndTime != 0 && req.StartTime > req.EndTime {
+		return nil, xerr.NewErrMsg("start_time must not be after end_time")
+	}
+	if req.StartTime < 0 || req.EndTime < 0 || !validPositiveIDs(req.Subscribers) {
+		return nil, xerr.NewErrMsg("invalid quota task filter")
+	}
 	count, err := s.selector.CountSubscribesByFilter(ctx, &usersub.SubscribeFilter{
 		Subscribers: req.Subscribers,
 		IsActive:    req.IsActive,
@@ -369,12 +428,15 @@ func (s *Service) QueryQuotaTaskPreCount(ctx context.Context, req *dto.QueryQuot
 	})
 	if err != nil {
 		logger.WithContext(ctx).Errorf("[QueryQuotaTaskPreCount] count error: %v", err.Error())
-		return nil, err
+		return nil, xerr.NewErrCode(xerr.DatabaseQueryError)
 	}
 	return &dto.QueryQuotaTaskPreCountResponse{Count: count}, nil
 }
 
 func (s *Service) QueryQuotaTaskStatus(ctx context.Context, req *dto.QueryQuotaTaskStatusRequest) (*dto.QueryQuotaTaskStatusResponse, error) {
+	if req == nil || req.Id <= 0 {
+		return nil, xerr.NewErrMsg("invalid task id")
+	}
 	data, err := s.tasks.FindOneByType(ctx, req.Id, task.TypeQuota)
 	if err != nil {
 		logger.WithContext(ctx).Errorf("[QueryQuotaTaskStatus] failed to get quota task: %v", err.Error())
@@ -386,4 +448,101 @@ func (s *Service) QueryQuotaTaskStatus(ctx context.Context, req *dto.QueryQuotaT
 		Total:   int64(data.Total),
 		Errors:  data.Errors,
 	}, nil
+}
+
+func (s *Service) markTaskEnqueueFailed(ctx context.Context, data *task.Task, reason string) {
+	updateCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	updated, err := s.tasks.UpdateStatusAndErrorFrom(updateCtx, data.Id, task.Type(data.Type), []int8{task.StatusPending}, task.StatusEnqueueFailed, reason)
+	if err != nil {
+		logger.WithContext(updateCtx).Errorf("failed to record marketing task enqueue failure: %v", err)
+		return
+	}
+	if !updated {
+		logger.WithContext(updateCtx).Errorw("marketing task enqueue failed after task execution had already started",
+			logger.Field("task_id", data.Id))
+		return
+	}
+	data.Status = task.StatusEnqueueFailed
+	data.Errors = reason
+}
+
+func validateBatchEmailRequest(req *dto.CreateBatchSendEmailTaskRequest) error {
+	if req == nil {
+		return xerr.NewErrMsg("request is required")
+	}
+	if strings.TrimSpace(req.Subject) == "" || strings.TrimSpace(req.Content) == "" {
+		return xerr.NewErrMsg("email subject and content are required")
+	}
+	if req.Scope < task.ScopeAll.Int8() || req.Scope > task.ScopeSkip.Int8() {
+		return xerr.NewErrMsg("invalid email scope")
+	}
+	if req.RegisterStartTime != 0 && req.RegisterEndTime != 0 && req.RegisterStartTime > req.RegisterEndTime {
+		return xerr.NewErrMsg("register_start_time must not be after register_end_time")
+	}
+	if req.RegisterStartTime < 0 || req.RegisterEndTime < 0 {
+		return xerr.NewErrMsg("registration timestamps must not be negative")
+	}
+	if req.Scheduled < 0 {
+		return xerr.NewErrMsg("scheduled must not be negative")
+	}
+	return nil
+}
+
+func validateQuotaRequest(req *dto.CreateQuotaTaskRequest) error {
+	if req == nil {
+		return xerr.NewErrMsg("request is required")
+	}
+	if req.StartTime != 0 && req.EndTime != 0 && req.StartTime > req.EndTime {
+		return xerr.NewErrMsg("start_time must not be after end_time")
+	}
+	if req.StartTime < 0 || req.EndTime < 0 || !validPositiveIDs(req.Subscribers) {
+		return xerr.NewErrMsg("invalid quota task filter")
+	}
+	if !req.ResetTraffic && req.Days == 0 && req.GiftValue == 0 {
+		return xerr.NewErrMsg("at least one quota action is required")
+	}
+	maxInt := uint64(^uint(0) >> 1)
+	if req.Days > maxInt {
+		return xerr.NewErrMsg("days is too large")
+	}
+	if req.GiftValue == 0 {
+		if req.GiftType != 0 {
+			return xerr.NewErrMsg("gift_type requires a positive gift_value")
+		}
+		return nil
+	}
+	if req.GiftType != 1 && req.GiftType != 2 {
+		return xerr.NewErrMsg("gift_type must be fixed or ratio when gift_value is set")
+	}
+	if req.GiftValue > math.MaxInt64 {
+		return xerr.NewErrMsg("gift_value is too large")
+	}
+	return nil
+}
+
+func normalizeAdditionalEmails(raw string) ([]string, error) {
+	lines := strings.Split(strings.ReplaceAll(raw, "\r\n", "\n"), "\n")
+	emails := make([]string, 0, len(lines))
+	for _, line := range lines {
+		address := strings.TrimSpace(line)
+		if address == "" {
+			continue
+		}
+		parsed, err := mail.ParseAddress(address)
+		if err != nil || !strings.EqualFold(parsed.Address, address) {
+			return nil, fmt.Errorf("invalid additional email address: %s", address)
+		}
+		emails = append(emails, strings.ToLower(parsed.Address))
+	}
+	return tool.RemoveDuplicateElements(emails...), nil
+}
+
+func validPositiveIDs(ids []int64) bool {
+	for _, id := range ids {
+		if id <= 0 {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/module/support/marketing_test.go
+++ b/internal/module/support/marketing_test.go
@@ -2,6 +2,7 @@ package support_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ type fakeTaskRepo struct {
 	inserted      *taskEntity.Task
 	statusUpdates []statusUpdate
 	findOne       *taskEntity.Task
+	statusCtxErr  error
 }
 
 func (f *fakeTaskRepo) Insert(_ context.Context, data *taskEntity.Task) error {
@@ -28,7 +30,10 @@ func (f *fakeTaskRepo) FindOne(_ context.Context, _ int64) (*taskEntity.Task, er
 	return f.findOne, nil
 }
 
-func (f *fakeTaskRepo) FindOneByType(_ context.Context, _ int64, _ taskEntity.Type) (*taskEntity.Task, error) {
+func (f *fakeTaskRepo) FindOneByType(_ context.Context, _ int64, typ taskEntity.Type) (*taskEntity.Task, error) {
+	if f.findOne == nil || f.findOne.Type != int8(typ) {
+		return nil, errors.New("task not found")
+	}
 	return f.findOne, nil
 }
 
@@ -38,9 +43,51 @@ func (f *fakeTaskRepo) QueryTaskList(_ context.Context, _ *taskEntity.Filter) (i
 
 func (f *fakeTaskRepo) Update(_ context.Context, _ *taskEntity.Task) error { return nil }
 
+func (f *fakeTaskRepo) UpdateActive(_ context.Context, data *taskEntity.Task) (bool, error) {
+	f.findOne = data
+	return true, nil
+}
+
 func (f *fakeTaskRepo) UpdateStatus(_ context.Context, id int64, status int8) error {
 	f.statusUpdates = append(f.statusUpdates, statusUpdate{ticketID: id, status: uint8(status)})
 	return nil
+}
+
+func (f *fakeTaskRepo) UpdateStatusFrom(_ context.Context, id int64, typ taskEntity.Type, from []int8, status int8) (bool, error) {
+	if f.findOne == nil || f.findOne.Id != id || f.findOne.Type != int8(typ) {
+		return false, nil
+	}
+	allowed := false
+	for _, candidate := range from {
+		allowed = allowed || f.findOne.Status == candidate
+	}
+	if !allowed {
+		return false, nil
+	}
+	f.findOne.Status = status
+	f.statusUpdates = append(f.statusUpdates, statusUpdate{ticketID: id, status: uint8(status)})
+	return true, nil
+}
+
+func (f *fakeTaskRepo) UpdateStatusAndErrorFrom(ctx context.Context, id int64, typ taskEntity.Type, from []int8, status int8, taskError string) (bool, error) {
+	f.statusCtxErr = ctx.Err()
+	target := f.findOne
+	if f.inserted != nil && f.inserted.Id == id && f.inserted.Type == int8(typ) {
+		target = f.inserted
+	}
+	if target == nil || target.Id != id || target.Type != int8(typ) {
+		return false, nil
+	}
+	allowed := false
+	for _, candidate := range from {
+		allowed = allowed || target.Status == candidate
+	}
+	if !allowed {
+		return false, nil
+	}
+	target.Status = status
+	target.Errors = taskError
+	return true, nil
 }
 
 type fakeRecipients struct {
@@ -72,16 +119,26 @@ type fakeMarketingQueue struct {
 	emailTaskID int64
 	processAt   time.Time
 	quotaTaskID int64
+	emailErr    error
+	quotaErr    error
+	onEmail     func()
+	onQuota     func()
 }
 
 func (f *fakeMarketingQueue) EnqueueBatchEmail(_ context.Context, taskID int64, processAt time.Time) (string, error) {
 	f.emailTaskID, f.processAt = taskID, processAt
-	return "queue-1", nil
+	if f.onEmail != nil {
+		f.onEmail()
+	}
+	return "queue-1", f.emailErr
 }
 
 func (f *fakeMarketingQueue) EnqueueQuota(_ context.Context, taskID int64) error {
 	f.quotaTaskID = taskID
-	return nil
+	if f.onQuota != nil {
+		f.onQuota()
+	}
+	return f.quotaErr
 }
 
 type fakeStopper struct {
@@ -97,7 +154,11 @@ type marketingFakes struct {
 }
 
 func newMarketingService(recipients fakeRecipients, targets fakeQuotaTargets) (support.Service, *marketingFakes) {
-	fakes := &marketingFakes{tasks: &fakeTaskRepo{}, queue: &fakeMarketingQueue{}, stopper: &fakeStopper{}}
+	fakes := &marketingFakes{
+		tasks:   &fakeTaskRepo{findOne: &taskEntity.Task{Id: 42, Type: taskEntity.TypeEmail, Status: taskEntity.StatusPending}},
+		queue:   &fakeMarketingQueue{},
+		stopper: &fakeStopper{},
+	}
 	svc := support.New(support.Deps{
 		Tasks:        fakes.tasks,
 		Recipients:   recipients,
@@ -112,7 +173,7 @@ func TestCreateBatchSendEmailTaskRejectsEmptyScope(t *testing.T) {
 	svc, fakes := newMarketingService(fakeRecipients{}, fakeQuotaTargets{})
 
 	err := svc.CreateBatchSendEmailTask(context.Background(), &dto.CreateBatchSendEmailTaskRequest{
-		Scope: taskEntity.ScopeAll.Int8(),
+		Subject: "subject", Content: "content", Scope: taskEntity.ScopeAll.Int8(),
 	})
 	if err == nil {
 		t.Fatal("empty recipient list for a non-skip scope must be rejected")
@@ -126,7 +187,7 @@ func TestCreateBatchSendEmailTaskSkipScopeRequiresAdditional(t *testing.T) {
 	svc, fakes := newMarketingService(fakeRecipients{}, fakeQuotaTargets{})
 
 	err := svc.CreateBatchSendEmailTask(context.Background(), &dto.CreateBatchSendEmailTaskRequest{
-		Scope: taskEntity.ScopeSkip.Int8(),
+		Subject: "subject", Content: "content", Scope: taskEntity.ScopeSkip.Int8(),
 	})
 	if err == nil {
 		t.Fatal("skip scope without additional addresses must be rejected")
@@ -140,6 +201,8 @@ func TestCreateBatchSendEmailTaskDedupesAndEnqueues(t *testing.T) {
 	svc, fakes := newMarketingService(fakeRecipients{emails: []string{"a@x.com", "a@x.com", "b@x.com"}}, fakeQuotaTargets{})
 
 	err := svc.CreateBatchSendEmailTask(context.Background(), &dto.CreateBatchSendEmailTaskRequest{
+		Subject:    "subject",
+		Content:    "content",
 		Scope:      taskEntity.ScopeAll.Int8(),
 		Additional: "b@x.com\nc@x.com",
 	})
@@ -161,10 +224,23 @@ func TestCreateBatchSendEmailTaskDedupesAndEnqueues(t *testing.T) {
 	}
 }
 
+func TestPreSendEmailCountMatchesDeduplicatedCampaignRecipients(t *testing.T) {
+	svc, _ := newMarketingService(fakeRecipients{emails: []string{"a@x.com", "b@x.com"}}, fakeQuotaTargets{})
+	resp, err := svc.GetPreSendEmailCount(context.Background(), &dto.GetPreSendEmailCountRequest{
+		Scope: taskEntity.ScopeAll.Int8(), Additional: " b@x.com\r\nc@x.com ",
+	})
+	if err != nil {
+		t.Fatalf("GetPreSendEmailCount: %v", err)
+	}
+	if resp.Count != 3 {
+		t.Fatalf("pre-send count = %d, want 3", resp.Count)
+	}
+}
+
 func TestCreateQuotaTaskRejectsNoSubscribers(t *testing.T) {
 	svc, fakes := newMarketingService(fakeRecipients{}, fakeQuotaTargets{})
 
-	if err := svc.CreateQuotaTask(context.Background(), &dto.CreateQuotaTaskRequest{}); err == nil {
+	if err := svc.CreateQuotaTask(context.Background(), &dto.CreateQuotaTaskRequest{Days: 1}); err == nil {
 		t.Fatal("quota task without matching subscribers must be rejected")
 	}
 	if fakes.tasks.inserted != nil {
@@ -196,7 +272,76 @@ func TestStopBatchSendEmailTaskStopsWorkerAndMarksTask(t *testing.T) {
 	if len(fakes.stopper.stopped) != 1 || fakes.stopper.stopped[0] != 42 {
 		t.Fatalf("worker not stopped: %+v", fakes.stopper.stopped)
 	}
-	if len(fakes.tasks.statusUpdates) != 1 || fakes.tasks.statusUpdates[0] != (statusUpdate{ticketID: 42, status: 2}) {
-		t.Fatalf("task status must be set to 2 (stopped): %+v", fakes.tasks.statusUpdates)
+	if len(fakes.tasks.statusUpdates) != 1 || fakes.tasks.statusUpdates[0] != (statusUpdate{ticketID: 42, status: uint8(taskEntity.StatusCancelled)}) {
+		t.Fatalf("task status must be set to cancelled: %+v", fakes.tasks.statusUpdates)
+	}
+}
+
+func TestCreateMarketingTasksMarkEnqueueFailure(t *testing.T) {
+	t.Run("email", func(t *testing.T) {
+		svc, fakes := newMarketingService(fakeRecipients{emails: []string{"a@x.com"}}, fakeQuotaTargets{})
+		fakes.queue.emailErr = errors.New("redis unavailable")
+		err := svc.CreateBatchSendEmailTask(context.Background(), &dto.CreateBatchSendEmailTaskRequest{
+			Subject: "subject", Content: "content", Scope: taskEntity.ScopeAll.Int8(),
+		})
+		if err == nil || fakes.tasks.inserted.Status != taskEntity.StatusEnqueueFailed || fakes.tasks.inserted.Errors == "" {
+			t.Fatalf("enqueue failure was not persisted: task=%+v err=%v", fakes.tasks.inserted, err)
+		}
+	})
+
+	t.Run("quota", func(t *testing.T) {
+		svc, fakes := newMarketingService(fakeRecipients{}, fakeQuotaTargets{ids: []int64{4}})
+		fakes.queue.quotaErr = errors.New("redis unavailable")
+		err := svc.CreateQuotaTask(context.Background(), &dto.CreateQuotaTaskRequest{Days: 1})
+		if err == nil || fakes.tasks.inserted.Status != taskEntity.StatusEnqueueFailed || fakes.tasks.inserted.Errors == "" {
+			t.Fatalf("enqueue failure was not persisted: task=%+v err=%v", fakes.tasks.inserted, err)
+		}
+	})
+
+	t.Run("started task wins enqueue response race", func(t *testing.T) {
+		svc, fakes := newMarketingService(fakeRecipients{}, fakeQuotaTargets{ids: []int64{4}})
+		fakes.queue.quotaErr = errors.New("redis response lost")
+		fakes.queue.onQuota = func() { fakes.tasks.inserted.Status = taskEntity.StatusInProgress }
+		err := svc.CreateQuotaTask(context.Background(), &dto.CreateQuotaTaskRequest{Days: 1})
+		if err == nil {
+			t.Fatal("enqueue response error must still be reported")
+		}
+		if fakes.tasks.inserted.Status != taskEntity.StatusInProgress {
+			t.Fatalf("enqueue error overwrote a task that had already started: %+v", fakes.tasks.inserted)
+		}
+	})
+
+	t.Run("failure state survives request cancellation", func(t *testing.T) {
+		svc, fakes := newMarketingService(fakeRecipients{emails: []string{"a@x.com"}}, fakeQuotaTargets{})
+		fakes.queue.emailErr = errors.New("redis unavailable")
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := svc.CreateBatchSendEmailTask(ctx, &dto.CreateBatchSendEmailTaskRequest{
+			Subject: "subject", Content: "content", Scope: taskEntity.ScopeAll.Int8(),
+		})
+		if err == nil || fakes.tasks.inserted.Status != taskEntity.StatusEnqueueFailed {
+			t.Fatalf("enqueue failure was not recorded after cancellation: task=%+v err=%v", fakes.tasks.inserted, err)
+		}
+		if fakes.tasks.statusCtxErr != nil {
+			t.Fatalf("enqueue failure update inherited canceled request context: %v", fakes.tasks.statusCtxErr)
+		}
+	})
+}
+
+func TestCreateMarketingTasksValidateDangerousInputs(t *testing.T) {
+	svc, fakes := newMarketingService(fakeRecipients{emails: []string{"a@x.com"}}, fakeQuotaTargets{ids: []int64{4}})
+	if err := svc.CreateBatchSendEmailTask(context.Background(), &dto.CreateBatchSendEmailTaskRequest{
+		Subject: "subject", Content: "content", Scope: taskEntity.ScopeSkip.Int8(), Additional: "not-an-email",
+	}); err == nil {
+		t.Fatal("invalid additional email must be rejected")
+	}
+	if err := svc.CreateQuotaTask(context.Background(), &dto.CreateQuotaTaskRequest{}); err == nil {
+		t.Fatal("quota task without an action must be rejected")
+	}
+	if err := svc.CreateQuotaTask(context.Background(), &dto.CreateQuotaTaskRequest{GiftValue: 10}); err == nil {
+		t.Fatal("gift value without a gift type must be rejected")
+	}
+	if fakes.tasks.inserted != nil {
+		t.Fatalf("invalid requests must not create tasks: %+v", fakes.tasks.inserted)
 	}
 }

--- a/internal/repository/contracts_platform.go
+++ b/internal/repository/contracts_platform.go
@@ -57,7 +57,10 @@ type TaskRepo interface {
 	FindOneByType(ctx context.Context, id int64, typ task.Type) (*task.Task, error)
 	QueryTaskList(ctx context.Context, filter *task.Filter) (int64, []*task.Task, error)
 	Update(ctx context.Context, data *task.Task) error
+	UpdateActive(ctx context.Context, data *task.Task) (bool, error)
 	UpdateStatus(ctx context.Context, id int64, status int8) error
+	UpdateStatusFrom(ctx context.Context, id int64, typ task.Type, from []int8, status int8) (bool, error)
+	UpdateStatusAndErrorFrom(ctx context.Context, id int64, typ task.Type, from []int8, status int8, taskError string) (bool, error)
 }
 
 // ClientRepo subscribe application 数据访问接口

--- a/internal/svc/modules.go
+++ b/internal/svc/modules.go
@@ -573,18 +573,37 @@ type marketingQueue struct {
 }
 
 func (q marketingQueue) EnqueueBatchEmail(ctx context.Context, taskID int64, processAt time.Time) (string, error) {
+	queueTaskID := fmt.Sprintf("marketing-email-%d-initial", taskID)
 	t := asynq.NewTask(queuetypes.ScheduledBatchSendEmail, []byte(strconv.FormatInt(taskID, 10)))
-	info, err := q.client.EnqueueContext(ctx, t, asynq.ProcessAt(processAt))
-	if err != nil {
+	if err := q.enqueueIdempotent(ctx, t, queueTaskID, asynq.ProcessAt(processAt)); err != nil {
 		return "", err
 	}
-	return info.ID, nil
+	return queueTaskID, nil
 }
 
 func (q marketingQueue) EnqueueQuota(ctx context.Context, taskID int64) error {
 	t := asynq.NewTask(queuetypes.ForthwithQuotaTask, []byte(strconv.FormatInt(taskID, 10)))
-	_, err := q.client.EnqueueContext(ctx, t)
-	return err
+	return q.enqueueIdempotent(ctx, t, fmt.Sprintf("marketing-quota-%d", taskID))
+}
+
+// enqueueIdempotent retries once with the same task ID on a detached bounded
+// context. This resolves the common "Redis accepted the write but the client
+// lost the response" case as an ID conflict instead of falsely abandoning a
+// durable database task.
+func (q marketingQueue) enqueueIdempotent(ctx context.Context, t *asynq.Task, taskID string, opts ...asynq.Option) error {
+	options := append(append([]asynq.Option{}, opts...), asynq.TaskID(taskID))
+	_, err := q.client.EnqueueContext(ctx, t, options...)
+	if err == nil || errors.Is(err, asynq.ErrTaskIDConflict) {
+		return nil
+	}
+
+	retryCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	_, retryErr := q.client.EnqueueContext(retryCtx, t, options...)
+	if retryErr == nil || errors.Is(retryErr, asynq.ErrTaskIDConflict) {
+		return nil
+	}
+	return errors.Join(err, retryErr)
 }
 
 // emailWorkerStopper adapts the global batch-email worker manager to the

--- a/internal/worker/email/manager.go
+++ b/internal/worker/email/manager.go
@@ -3,7 +3,6 @@ package emailworker
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/perfect-panel/server/internal/module/platform/entity/task"
 	emailpkg "github.com/perfect-panel/server/pkg/email"
@@ -12,69 +11,62 @@ import (
 
 // TaskStore is the minimal task repository interface needed by the batch-email worker.
 type TaskStore interface {
-	FindOne(ctx context.Context, id int64) (*task.Task, error)
-	Update(ctx context.Context, data *task.Task) error
+	FindOneByType(ctx context.Context, id int64, typ task.Type) (*task.Task, error)
+	UpdateActive(ctx context.Context, data *task.Task) (bool, error)
 }
 
 var (
 	Manager *WorkerManager
 	once    sync.Once
-	limit   sync.RWMutex
+	sendOne = make(chan struct{}, 1)
 )
 
 // WorkerManager owns asynchronous batch-email workers. It is an application
 // worker, so it belongs in internal rather than the reusable email package.
 type WorkerManager struct {
-	tasks   TaskStore
-	sender  emailpkg.Sender
 	mutex   sync.RWMutex
 	workers map[int64]*Worker
 	cancels map[int64]context.CancelFunc
 }
 
-func NewWorkerManager(tasks TaskStore, sender emailpkg.Sender) *WorkerManager {
+func NewWorkerManager() *WorkerManager {
 	if Manager != nil {
 		return Manager
 	}
 	once.Do(func() {
 		Manager = &WorkerManager{
-			tasks:   tasks,
 			workers: make(map[int64]*Worker),
 			cancels: make(map[int64]context.CancelFunc),
-			sender:  sender,
 		}
 	})
-	go func() {
-		for {
-			select {
-			case <-time.After(time.Minute):
-				checkWorker()
-			}
-		}
-	}()
 	return Manager
 }
 
-// AddWorker starts a worker only when one is not already processing the task.
-func (m *WorkerManager) AddWorker(id int64) {
+// RunWorker keeps queue acknowledgement coupled to the actual campaign run.
+// A duplicate delivery in the same process is harmless: the existing worker
+// remains authoritative for that database task.
+func (m *WorkerManager) RunWorker(ctx context.Context, id int64, tasks TaskStore, sender emailpkg.Sender) error {
 	m.mutex.Lock()
-	defer m.mutex.Unlock()
-	if _, exists := m.workers[id]; !exists {
-		ctx, cancel := context.WithCancel(context.Background())
-		worker := NewWorker(ctx, id, m.tasks, m.sender)
-		m.workers[id] = worker
-		m.cancels[id] = cancel
-		go worker.Start()
-		logger.Info("Batch Send Email",
-			logger.Field("message", "Added new worker"),
-			logger.Field("task_id", id),
-		)
-		return
+	if _, exists := m.workers[id]; exists {
+		m.mutex.Unlock()
+		logger.Info("Batch Send Email", logger.Field("message", "Worker already exists"), logger.Field("task_id", id))
+		return nil
 	}
-	logger.Info("Batch Send Email",
-		logger.Field("message", "Worker already exists"),
-		logger.Field("task_id", id),
-	)
+	workerCtx, cancel := context.WithCancel(ctx)
+	worker := NewWorker(workerCtx, id, tasks, sender)
+	m.workers[id] = worker
+	m.cancels[id] = cancel
+	m.mutex.Unlock()
+
+	logger.Info("Batch Send Email", logger.Field("message", "Added new worker"), logger.Field("task_id", id))
+	err := worker.Start()
+
+	m.mutex.Lock()
+	delete(m.workers, id)
+	delete(m.cancels, id)
+	m.mutex.Unlock()
+	cancel()
+	return err
 }
 
 // GetWorker returns the worker currently assigned to id.
@@ -111,26 +103,4 @@ func (m *WorkerManager) RemoveWorker(id int64) {
 		logger.Field("message", "Worker not found for removal"),
 		logger.Field("task_id", id),
 	)
-}
-
-func checkWorker() {
-	if Manager == nil {
-		return
-	}
-	Manager.mutex.Lock()
-	defer Manager.mutex.Unlock()
-	for id, worker := range Manager.workers {
-		if worker.IsRunning() != 2 {
-			continue
-		}
-		delete(Manager.workers, id)
-		if cancelFunc, ok := Manager.cancels[id]; ok {
-			cancelFunc()
-			delete(Manager.cancels, id)
-		}
-		logger.Info("Batch Send Email",
-			logger.Field("message", "Removed completed worker"),
-			logger.Field("task_id", id),
-		)
-	}
 }

--- a/internal/worker/email/worker.go
+++ b/internal/worker/email/worker.go
@@ -3,11 +3,14 @@ package emailworker
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/perfect-panel/server/internal/module/platform/entity/task"
 	emailpkg "github.com/perfect-panel/server/pkg/email"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 	"github.com/perfect-panel/server/pkg/tool"
 )
 
@@ -17,12 +20,23 @@ type ErrorInfo struct {
 	Time  int64  `json:"time"`
 }
 
+// DailyLimitReached asks the queue shell to persist a continuation for the
+// next civil day instead of keeping one queue worker asleep for hours.
+type DailyLimitReached struct {
+	NextAt time.Time
+}
+
+var ErrTaskNotActive = errors.New("batch email task is no longer active")
+
+func (e *DailyLimitReached) Error() string {
+	return fmt.Sprintf("batch email daily limit reached; resume at %s", e.NextAt.Format(time.RFC3339))
+}
+
 type Worker struct {
 	id     int64
 	tasks  TaskStore
 	ctx    context.Context
 	sender emailpkg.Sender
-	status uint8
 }
 
 func NewWorker(ctx context.Context, id int64, tasks TaskStore, sender emailpkg.Sender) *Worker {
@@ -31,44 +45,41 @@ func NewWorker(ctx context.Context, id int64, tasks TaskStore, sender emailpkg.S
 
 func (w *Worker) GetID() int64 { return w.id }
 
-func (w *Worker) IsRunning() uint8 { return w.status }
-
 // Start processes a batch-email task until completion or cancellation.
-func (w *Worker) Start() {
-	limit.Lock()
-	defer limit.Unlock()
-	taskInfo, err := w.tasks.FindOne(w.ctx, w.id)
+func (w *Worker) Start() error {
+	taskInfo, err := w.tasks.FindOneByType(w.ctx, w.id, task.TypeEmail)
 	if err != nil {
 		logger.Error("Batch Send Email", logger.Field("message", "Failed to find task"), logger.Field("error", err.Error()), logger.Field("task_id", w.id))
-		return
+		return err
 	}
-	if taskInfo.Status != 0 {
-		logger.Error("Batch Send Email", logger.Field("message", "Task already completed or in progress"), logger.Field("task_id", w.id))
-		return
+	if taskInfo.Status == task.StatusCompleted || taskInfo.Status == task.StatusFailed || taskInfo.Status == task.StatusCancelled || taskInfo.Status == task.StatusEnqueueFailed {
+		logger.Info("Batch Send Email", logger.Field("message", "Task is already terminal"), logger.Field("task_id", w.id), logger.Field("status", taskInfo.Status))
+		return nil
 	}
 
 	var scope task.EmailScope
 	if err := json.Unmarshal([]byte(taskInfo.Scope), &scope); err != nil {
 		logger.Error("Batch Send Email", logger.Field("message", "Failed to parse task scope"), logger.Field("error", err.Error()), logger.Field("task_id", w.id))
-		return
+		return w.failTask(taskInfo, fmt.Errorf("parse task scope: %w", err))
 	}
 	if len(scope.Recipients) == 0 && len(scope.Additional) == 0 {
 		logger.Error("Batch Send Email", logger.Field("message", "No recipients or additional emails provided"), logger.Field("task_id", w.id))
-		return
+		return w.failTask(taskInfo, fmt.Errorf("no recipients provided"))
 	}
 
 	var content task.EmailContent
 	if err := json.Unmarshal([]byte(taskInfo.Content), &content); err != nil {
 		logger.Error("Batch Send Email", logger.Field("message", "Failed to parse task content"), logger.Field("error", err.Error()), logger.Field("task_id", w.id))
-		return
+		return w.failTask(taskInfo, fmt.Errorf("parse task content: %w", err))
 	}
 
-	w.status = 1
 	recipients := tool.RemoveDuplicateElements(append(scope.Recipients, scope.Additional...)...)
 	if len(recipients) == 0 {
 		logger.Error("Batch Send Email", logger.Field("message", "No valid recipients found"), logger.Field("task_id", w.id))
-		w.status = 2
-		return
+		return w.failTask(taskInfo, fmt.Errorf("no valid recipients found"))
+	}
+	if taskInfo.Current > uint64(len(recipients)) {
+		return w.failTask(taskInfo, fmt.Errorf("task progress exceeds recipient count"))
 	}
 
 	interval := time.Second
@@ -76,40 +87,135 @@ func (w *Worker) Start() {
 		interval = time.Duration(scope.Interval) * time.Second
 	}
 
-	var errors []ErrorInfo
-	var count uint64
-	for _, recipient := range recipients {
+	var sendErrors []ErrorInfo
+	if taskInfo.Errors != "" {
+		if err := json.Unmarshal([]byte(taskInfo.Errors), &sendErrors); err != nil {
+			return w.failTask(taskInfo, fmt.Errorf("parse task errors: %w", err))
+		}
+	}
+	taskInfo.Status = task.StatusInProgress
+	if err := w.persist(taskInfo, &scope); err != nil {
+		return err
+	}
+
+	for index := int(taskInfo.Current); index < len(recipients); index++ {
+		if err := w.ensureDailyCapacity(&scope, taskInfo); err != nil {
+			return err
+		}
 		select {
 		case <-w.ctx.Done():
 			logger.Info("Batch Send Email", logger.Field("message", "Worker stopped by context cancellation"), logger.Field("task_id", w.id))
-			return
+			return w.ctx.Err()
 		default:
 		}
-		if taskInfo.Status == 0 {
-			taskInfo.Status = 1
-		}
 
-		if err := w.sender.Send([]string{recipient}, content.Subject, content.Content); err != nil {
-			logger.Error("Batch Send Email", logger.Field("message", "Failed to send email"), logger.Field("error", err.Error()), logger.Field("recipient", recipient), logger.Field("task_id", w.id))
-			errors = append(errors, ErrorInfo{Error: err.Error(), Email: recipient, Time: time.Now().Unix()})
-			text, _ := json.Marshal(errors)
+		recipient := recipients[index]
+		sendErr := w.send(recipient, content)
+		if errors.Is(sendErr, context.Canceled) || errors.Is(sendErr, context.DeadlineExceeded) {
+			return sendErr
+		}
+		if sendErr != nil {
+			logger.Error("Batch Send Email", logger.Field("message", "Failed to send email"), logger.Field("error", sendErr.Error()), logger.Field("task_id", w.id))
+			sendErrors = append(sendErrors, ErrorInfo{Error: sendErr.Error(), Email: recipient, Time: timeutil.Now().Unix()})
+			text, _ := json.Marshal(sendErrors)
 			taskInfo.Errors = string(text)
 		}
-		count++
-		taskInfo.Current = count
-		if err := w.tasks.Update(w.ctx, taskInfo); err != nil {
+		taskInfo.Current = uint64(index + 1)
+		scope.DailySent++
+		if err := w.persist(taskInfo, &scope); err != nil {
 			logger.Error("Batch Send Email", logger.Field("message", "Failed to update task progress"), logger.Field("error", err.Error()), logger.Field("task_id", w.id))
-			errors = append(errors, ErrorInfo{Error: err.Error(), Email: recipient, Time: time.Now().Unix()})
-			w.status = 2
+			return err
 		}
-		time.Sleep(interval)
+		if index+1 < len(recipients) {
+			if err := waitContext(w.ctx, interval); err != nil {
+				return err
+			}
+		}
 	}
-	taskInfo.Status = 2
-	w.status = 2
+	taskInfo.Status = task.StatusCompleted
+	failedRecipients := make(map[string]struct{}, len(sendErrors))
+	for _, item := range sendErrors {
+		if item.Email != "" {
+			failedRecipients[item.Email] = struct{}{}
+		}
+	}
+	if len(failedRecipients) >= len(recipients) {
+		taskInfo.Status = task.StatusFailed
+	}
 
-	if err := w.tasks.Update(w.ctx, taskInfo); err != nil {
+	if err := w.persist(taskInfo, &scope); err != nil {
 		logger.Error("Batch Send Email", logger.Field("message", "Failed to finalize task"), logger.Field("error", err.Error()), logger.Field("task_id", w.id))
-		return
+		return err
 	}
-	logger.Info("Batch Send Email", logger.Field("message", "Task completed successfully"), logger.Field("task_id", w.id), logger.Field("total_sent", count))
+	logger.Info("Batch Send Email", logger.Field("message", "Task completed"), logger.Field("task_id", w.id), logger.Field("total_attempted", taskInfo.Current))
+	return nil
+}
+
+func (w *Worker) send(recipient string, content task.EmailContent) error {
+	select {
+	case sendOne <- struct{}{}:
+		defer func() { <-sendOne }()
+	case <-w.ctx.Done():
+		return w.ctx.Err()
+	}
+	return w.sender.Send([]string{recipient}, content.Subject, content.Content)
+}
+
+func (w *Worker) persist(taskInfo *task.Task, scope *task.EmailScope) error {
+	scopeBytes, err := scope.Marshal()
+	if err != nil {
+		return err
+	}
+	taskInfo.Scope = string(scopeBytes)
+	updated, err := w.tasks.UpdateActive(w.ctx, taskInfo)
+	if err != nil {
+		return err
+	}
+	if !updated {
+		return ErrTaskNotActive
+	}
+	return nil
+}
+
+func (w *Worker) failTask(taskInfo *task.Task, cause error) error {
+	taskInfo.Status = task.StatusFailed
+	taskInfo.Errors = cause.Error()
+	updated, err := w.tasks.UpdateActive(w.ctx, taskInfo)
+	if err != nil {
+		return fmt.Errorf("record failed email task: %w", err)
+	}
+	if !updated {
+		return ErrTaskNotActive
+	}
+	return nil
+}
+
+func (w *Worker) ensureDailyCapacity(scope *task.EmailScope, taskInfo *task.Task) error {
+	if scope.Limit == 0 {
+		return nil
+	}
+	now := timeutil.Now()
+	today := now.Format(time.DateOnly)
+	if scope.DailyDate != today {
+		scope.DailyDate = today
+		scope.DailySent = 0
+		return w.persist(taskInfo, scope)
+	}
+	if scope.DailySent < scope.Limit {
+		return nil
+	}
+	tomorrow := now.AddDate(0, 0, 1)
+	nextDay := time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), 0, 0, 0, 0, tomorrow.Location())
+	return &DailyLimitReached{NextAt: nextDay}
+}
+
+func waitContext(ctx context.Context, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }

--- a/internal/worker/email/worker_test.go
+++ b/internal/worker/email/worker_test.go
@@ -1,0 +1,153 @@
+package emailworker
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/perfect-panel/server/internal/module/platform/entity/task"
+)
+
+type workerTaskStore struct {
+	task         *task.Task
+	updateErr    error
+	updates      int
+	rejectActive bool
+}
+
+func (s *workerTaskStore) FindOneByType(_ context.Context, _ int64, typ task.Type) (*task.Task, error) {
+	if s.task == nil || s.task.Type != int8(typ) {
+		return nil, errors.New("task not found")
+	}
+	data := *s.task
+	return &data, nil
+}
+
+func (s *workerTaskStore) UpdateActive(_ context.Context, data *task.Task) (bool, error) {
+	if s.updateErr != nil {
+		return false, s.updateErr
+	}
+	if s.rejectActive {
+		return false, nil
+	}
+	s.updates++
+	s.task = data
+	return true, nil
+}
+
+type workerSender struct {
+	sent []string
+	err  error
+}
+
+func (s *workerSender) Send(to []string, _, _ string) error {
+	s.sent = append(s.sent, to...)
+	return s.err
+}
+
+func newEmailTask(t *testing.T, status int8, current uint64, recipients ...string) *task.Task {
+	t.Helper()
+	scope, err := (&task.EmailScope{Recipients: recipients, Limit: 10}).Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	content, err := (&task.EmailContent{Subject: "subject", Content: "content"}).Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &task.Task{Id: 7, Type: task.TypeEmail, Status: status, Current: current, Total: uint64(len(recipients)), Scope: string(scope), Content: string(content)}
+}
+
+func TestWorkerResumesFromPersistedProgress(t *testing.T) {
+	store := &workerTaskStore{task: newEmailTask(t, task.StatusInProgress, 1, "a@example.com", "b@example.com")}
+	sender := &workerSender{}
+
+	if err := NewWorker(context.Background(), 7, store, sender).Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if len(sender.sent) != 1 || sender.sent[0] != "b@example.com" {
+		t.Fatalf("resumed sends = %v, want only second recipient", sender.sent)
+	}
+	if store.task.Status != task.StatusCompleted || store.task.Current != 2 {
+		t.Fatalf("final task = %+v", store.task)
+	}
+	var scope task.EmailScope
+	if err := scope.Unmarshal([]byte(store.task.Scope)); err != nil {
+		t.Fatal(err)
+	}
+	if scope.DailyDate == "" || scope.DailySent != 1 {
+		t.Fatalf("daily limit state was not persisted: %+v", scope)
+	}
+}
+
+func TestWorkerMarksAllSendFailuresFailed(t *testing.T) {
+	store := &workerTaskStore{task: newEmailTask(t, task.StatusPending, 0, "a@example.com")}
+	sender := &workerSender{err: errors.New("smtp rejected")}
+
+	if err := NewWorker(context.Background(), 7, store, sender).Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if store.task.Status != task.StatusFailed || store.task.Errors == "" || store.task.Current != 1 {
+		t.Fatalf("failed send task = %+v", store.task)
+	}
+}
+
+func TestWorkerReturnsPersistenceFailureForQueueRetry(t *testing.T) {
+	store := &workerTaskStore{task: newEmailTask(t, task.StatusPending, 0, "a@example.com"), updateErr: errors.New("database unavailable")}
+	if err := NewWorker(context.Background(), 7, store, &workerSender{}).Start(); err == nil {
+		t.Fatal("persistence failure must be returned to the queue")
+	}
+}
+
+func TestWorkerCannotOverwriteCancelledTaskWhenRecordingInvalidData(t *testing.T) {
+	data := newEmailTask(t, task.StatusPending, 0, "a@example.com")
+	data.Scope = `{`
+	store := &workerTaskStore{task: data, rejectActive: true}
+
+	err := NewWorker(context.Background(), 7, store, &workerSender{}).Start()
+	if !errors.Is(err, ErrTaskNotActive) {
+		t.Fatalf("Start error = %v, want ErrTaskNotActive", err)
+	}
+	if store.task.Status != task.StatusPending || store.task.Errors != "" {
+		t.Fatalf("rejected stale update changed stored task: %+v", store.task)
+	}
+}
+
+func TestWorkerRejectsCorruptPersistedErrors(t *testing.T) {
+	data := newEmailTask(t, task.StatusPending, 0, "a@example.com")
+	data.Errors = `{`
+	store := &workerTaskStore{task: data}
+	sender := &workerSender{}
+
+	if err := NewWorker(context.Background(), 7, store, sender).Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if store.task.Status != task.StatusFailed || len(sender.sent) != 0 {
+		t.Fatalf("corrupt task errors were ignored: task=%+v sent=%v", store.task, sender.sent)
+	}
+}
+
+func TestWorkerReturnsDailyContinuationWithoutSending(t *testing.T) {
+	data := newEmailTask(t, task.StatusInProgress, 0, "a@example.com")
+	var scope task.EmailScope
+	if err := scope.Unmarshal([]byte(data.Scope)); err != nil {
+		t.Fatal(err)
+	}
+	scope.Limit = 1
+	scope.DailySent = 1
+	scope.DailyDate = time.Now().Format(time.DateOnly)
+	encoded, _ := scope.Marshal()
+	data.Scope = string(encoded)
+	store := &workerTaskStore{task: data}
+	sender := &workerSender{}
+
+	err := NewWorker(context.Background(), 7, store, sender).Start()
+	var continuation *DailyLimitReached
+	if !errors.As(err, &continuation) || !continuation.NextAt.After(time.Now()) {
+		t.Fatalf("daily continuation error = %v", err)
+	}
+	if len(sender.sent) != 0 || store.task.Current != 0 || store.task.Status != task.StatusInProgress {
+		t.Fatalf("daily-limited worker changed delivery state: sent=%v task=%+v", sender.sent, store.task)
+	}
+}

--- a/ppanel.json
+++ b/ppanel.json
@@ -2667,10 +2667,16 @@
                     {
                         "type": "integer",
                         "name": "page",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
                     },
                     {
+                        "enum": [
+                            1,
+                            2,
+                            3,
+                            4,
+                            5
+                        ],
                         "type": "integer",
                         "name": "scope",
                         "in": "query"
@@ -2679,10 +2685,17 @@
                         "maximum": 100,
                         "type": "integer",
                         "name": "size",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
                     },
                     {
+                        "enum": [
+                            0,
+                            1,
+                            2,
+                            3,
+                            4,
+                            5
+                        ],
                         "type": "integer",
                         "name": "status",
                         "in": "query"
@@ -2945,17 +2958,23 @@
                     {
                         "type": "integer",
                         "name": "page",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
                     },
                     {
                         "maximum": 100,
                         "type": "integer",
                         "name": "size",
-                        "in": "query",
-                        "required": true
+                        "in": "query"
                     },
                     {
+                        "enum": [
+                            0,
+                            1,
+                            2,
+                            3,
+                            4,
+                            5
+                        ],
                         "type": "integer",
                         "name": "status",
                         "in": "query"
@@ -11705,6 +11724,11 @@
         },
         "dto.CreateBatchSendEmailTaskRequest": {
             "type": "object",
+            "required": [
+                "content",
+                "scope",
+                "subject"
+            ],
             "properties": {
                 "additional": {
                     "type": "string"
@@ -11719,16 +11743,26 @@
                     "type": "integer"
                 },
                 "register_end_time": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                 },
                 "register_start_time": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                 },
                 "scheduled": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                 },
                 "scope": {
-                    "type": "integer"
+                    "type": "integer",
+                    "enum": [
+                        1,
+                        2,
+                        3,
+                        4,
+                        5
+                    ]
                 },
                 "subject": {
                     "type": "string"
@@ -11953,10 +11987,16 @@
                     "type": "integer"
                 },
                 "end_time": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                 },
                 "gift_type": {
-                    "type": "integer"
+                    "type": "integer",
+                    "enum": [
+                        0,
+                        1,
+                        2
+                    ]
                 },
                 "gift_value": {
                     "type": "integer"
@@ -11968,7 +12008,8 @@
                     "type": "boolean"
                 },
                 "start_time": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                 },
                 "subscribers": {
                     "type": "array",
@@ -12961,6 +13002,9 @@
         },
         "dto.GetBatchSendEmailTaskStatusRequest": {
             "type": "object",
+            "required": [
+                "id"
+            ],
             "properties": {
                 "id": {
                     "type": "integer"
@@ -13152,7 +13196,13 @@
         },
         "dto.GetPreSendEmailCountRequest": {
             "type": "object",
+            "required": [
+                "scope"
+            ],
             "properties": {
+                "additional": {
+                    "type": "string"
+                },
                 "register_end_time": {
                     "type": "integer"
                 },
@@ -13160,7 +13210,14 @@
                     "type": "integer"
                 },
                 "scope": {
-                    "type": "integer"
+                    "type": "integer",
+                    "enum": [
+                        1,
+                        2,
+                        3,
+                        4,
+                        5
+                    ]
                 }
             }
         },
@@ -14865,13 +14922,15 @@
             "type": "object",
             "properties": {
                 "end_time": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                 },
                 "is_active": {
                     "type": "boolean"
                 },
                 "start_time": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 0
                 },
                 "subscribers": {
                     "type": "array",
@@ -15782,6 +15841,9 @@
         },
         "dto.StopBatchSendEmailTaskRequest": {
             "type": "object",
+            "required": [
+                "id"
+            ],
             "properties": {
                 "id": {
                     "type": "integer"

--- a/queue/logic/email/batchEmailLogic.go
+++ b/queue/logic/email/batchEmailLogic.go
@@ -2,13 +2,18 @@ package emailLogic
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"strconv"
 
 	"github.com/hibiken/asynq"
+	taskEntity "github.com/perfect-panel/server/internal/module/platform/entity/task"
 	"github.com/perfect-panel/server/internal/svc"
 	emailworker "github.com/perfect-panel/server/internal/worker/email"
 	"github.com/perfect-panel/server/pkg/email"
 	"github.com/perfect-panel/server/pkg/logger"
+	"github.com/perfect-panel/server/pkg/timeutil"
 )
 
 type BatchEmailLogic struct {
@@ -22,19 +27,15 @@ type ErrorInfo struct {
 }
 
 func NewBatchEmailLogic(svcCtx *svc.ServiceContext) *BatchEmailLogic {
-	return &BatchEmailLogic{
-		svcCtx: svcCtx,
-	}
+	return &BatchEmailLogic{svcCtx: svcCtx}
 }
 
-func (l *BatchEmailLogic) ProcessTask(ctx context.Context, task *asynq.Task) error {
-	// 解析任务负载
-	payload := task.Payload()
+func (l *BatchEmailLogic) ProcessTask(ctx context.Context, queuedTask *asynq.Task) error {
+	payload := queuedTask.Payload()
 	if len(payload) == 0 {
 		logger.Error("[BatchEmailLogic] ProcessTask failed: empty payload")
 		return asynq.SkipRetry
 	}
-	// 转换获取任务id
 	taskID, err := strconv.ParseInt(string(payload), 10, 64)
 	if err != nil {
 		logger.WithContext(ctx).Error("[BatchEmailLogic] ProcessTask failed: invalid task ID",
@@ -43,35 +44,90 @@ func (l *BatchEmailLogic) ProcessTask(ctx context.Context, task *asynq.Task) err
 		)
 		return asynq.SkipRetry
 	}
-	taskInfo, err := l.svcCtx.Store.Task().FindOne(ctx, taskID)
-	if err != nil {
-		logger.WithContext(ctx).Error("[BatchEmailLogic] ProcessTask failed",
-			logger.Field("error", err.Error()),
-			logger.Field("taskID", taskID),
-		)
-		return asynq.SkipRetry
+	if l.svcCtx == nil || l.svcCtx.Store == nil {
+		return errors.New("batch email task store is nil")
 	}
-
-	if taskInfo.Status != 0 {
-		logger.WithContext(ctx).Info("[BatchEmailLogic] ProcessTask skipped: task already processed",
-			logger.Field("taskID", taskID),
-			logger.Field("status", taskInfo.Status),
-		)
+	tasks := l.svcCtx.Store.Task()
+	taskInfo, err := tasks.FindOneByType(ctx, taskID, taskEntity.TypeEmail)
+	if err != nil {
+		return l.handleFailure(ctx, taskID, err)
+	}
+	if taskInfo.Status == taskEntity.StatusCompleted || taskInfo.Status == taskEntity.StatusCancelled || taskInfo.Status == taskEntity.StatusEnqueueFailed ||
+		(taskInfo.Status == taskEntity.StatusFailed && taskInfo.Current >= taskInfo.Total) {
 		return nil
 	}
-
+	if taskInfo.Status == taskEntity.StatusFailed {
+		updated, err := tasks.UpdateStatusFrom(ctx, taskID, taskEntity.TypeEmail, []int8{taskEntity.StatusFailed}, taskEntity.StatusPending)
+		if err != nil {
+			return err
+		}
+		if !updated {
+			return nil
+		}
+	}
 	sender, err := email.NewSender(l.svcCtx.Config.Email.Platform, l.svcCtx.Config.Email.PlatformConfig, l.svcCtx.Config.Site.SiteName)
 	if err != nil {
 		logger.WithContext(ctx).Error("[BatchEmailLogic] NewSender failed", logger.Field("error", err.Error()))
-		return nil
+		return l.handleFailure(ctx, taskID, err)
 	}
-	manager := emailworker.NewWorkerManager(l.svcCtx.Store.Task(), sender)
+	manager := emailworker.NewWorkerManager()
 	if manager == nil {
 		logger.WithContext(ctx).Error("[BatchEmailLogic] ProcessTask failed: worker manager is nil")
 		return asynq.SkipRetry
 	}
 
-	// 添加或获取 Worker 实例
-	manager.AddWorker(taskID)
-	return nil
+	err = manager.RunWorker(ctx, taskID, tasks, sender)
+	if errors.Is(err, emailworker.ErrTaskNotActive) {
+		return nil
+	}
+	var dailyLimit *emailworker.DailyLimitReached
+	if !errors.As(err, &dailyLimit) {
+		return l.handleFailure(ctx, taskID, err)
+	}
+	if l.svcCtx.Queue == nil {
+		return errors.New("batch email continuation queue is nil")
+	}
+	continuation := asynq.NewTask(queuedTask.Type(), queuedTask.Payload())
+	continuationID := fmt.Sprintf("marketing-email-%d-%s", taskID, dailyLimit.NextAt.Format("20060102"))
+	_, enqueueErr := l.svcCtx.Queue.EnqueueContext(ctx, continuation, asynq.ProcessAt(dailyLimit.NextAt), asynq.TaskID(continuationID))
+	if errors.Is(enqueueErr, asynq.ErrTaskIDConflict) {
+		return nil
+	}
+	return l.handleFailure(ctx, taskID, enqueueErr)
+}
+
+func (l *BatchEmailLogic) handleFailure(ctx context.Context, taskID int64, cause error) error {
+	if cause == nil {
+		return nil
+	}
+	retried, retryOK := asynq.GetRetryCount(ctx)
+	maxRetry, maxOK := asynq.GetMaxRetry(ctx)
+	if !retryOK || !maxOK || retried < maxRetry {
+		return cause
+	}
+	if l.svcCtx == nil || l.svcCtx.Store == nil {
+		return cause
+	}
+	tasks := l.svcCtx.Store.Task()
+	data, err := tasks.FindOneByType(ctx, taskID, taskEntity.TypeEmail)
+	if err != nil {
+		return errors.Join(cause, err)
+	}
+	data.Status = taskEntity.StatusFailed
+	var taskErrors []ErrorInfo
+	if data.Errors != "" {
+		if unmarshalErr := json.Unmarshal([]byte(data.Errors), &taskErrors); unmarshalErr != nil {
+			taskErrors = append(taskErrors, ErrorInfo{Error: data.Errors, Time: timeutil.Now().Unix()})
+		}
+	}
+	taskErrors = append(taskErrors, ErrorInfo{Error: cause.Error(), Time: timeutil.Now().Unix()})
+	encoded, marshalErr := json.Marshal(taskErrors)
+	if marshalErr != nil {
+		return errors.Join(cause, marshalErr)
+	}
+	data.Errors = string(encoded)
+	if _, err := tasks.UpdateActive(ctx, data); err != nil {
+		return errors.Join(cause, err)
+	}
+	return cause
 }

--- a/queue/logic/task/quotaLogic.go
+++ b/queue/logic/task/quotaLogic.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/hibiken/asynq"
+	taskEntity "github.com/perfect-panel/server/internal/module/platform/entity/task"
 	"github.com/perfect-panel/server/internal/module/subscription"
 	"github.com/perfect-panel/server/internal/svc"
 	"github.com/perfect-panel/server/pkg/logger"
@@ -19,9 +20,7 @@ type QuotaTaskLogic struct {
 }
 
 func NewQuotaTaskLogic(svcCtx *svc.ServiceContext) *QuotaTaskLogic {
-	return &QuotaTaskLogic{
-		svcCtx: svcCtx,
-	}
+	return &QuotaTaskLogic{svcCtx: svcCtx}
 }
 
 func (l *QuotaTaskLogic) ProcessTask(ctx context.Context, t *asynq.Task) error {
@@ -33,9 +32,31 @@ func (l *QuotaTaskLogic) ProcessTask(ctx context.Context, t *asynq.Task) error {
 		if errors.Is(err, subscription.ErrQuotaTaskUnretryable) {
 			return asynq.SkipRetry
 		}
+		if retried, ok := asynq.GetRetryCount(ctx); ok {
+			if maxRetry, maxOK := asynq.GetMaxRetry(ctx); maxOK && retried >= maxRetry {
+				l.markFailed(ctx, taskID, err)
+			}
+		}
 		return err
 	}
 	return nil
+}
+
+func (l *QuotaTaskLogic) markFailed(ctx context.Context, taskID int64, cause error) {
+	if l.svcCtx == nil || l.svcCtx.Store == nil {
+		return
+	}
+	tasks := l.svcCtx.Store.Task()
+	data, err := tasks.FindOneByType(ctx, taskID, taskEntity.TypeQuota)
+	if err != nil {
+		logger.WithContext(ctx).Error("[QuotaTaskLogic] failed to load exhausted task", logger.Field("error", err.Error()), logger.Field("taskID", taskID))
+		return
+	}
+	data.Status = taskEntity.StatusFailed
+	data.Errors = cause.Error()
+	if _, err := tasks.UpdateActive(ctx, data); err != nil {
+		logger.WithContext(ctx).Error("[QuotaTaskLogic] failed to mark exhausted task", logger.Field("error", err.Error()), logger.Field("taskID", taskID))
+	}
 }
 
 func (l *QuotaTaskLogic) parseTaskID(ctx context.Context, payload []byte) (int64, error) {


### PR DESCRIPTION
## Summary
- harden marketing task validation, type isolation, status transitions and enqueue recovery
- make batch email execution resumable, cancellable and daily-limit aware
- make quota grants transactionally idempotent and preserve NoLimit subscriptions
- add repository, worker, quota and filter regression coverage

## Validation
- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/module/platform/internal/repo ./internal/module/support ./internal/module/subscription/internal/quotatask ./internal/module/subscription/internal/repo ./internal/worker/email ./queue/logic/email`
- `./script/generate-swagger.sh`
- `git diff --check`